### PR TITLE
Redesign UI as Murderbot HUD and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # The Feed
 
-The Feed is a local daemon that polls a GitHub repository for issues labeled `memory`, classifies each one through a risk-based governor module, and lets you incorporate approved decisions directly into your local `CLAUDE.md` files — making team knowledge immediately available to Claude Code without any sync step, pull request, or central gatekeeper. Inspired by the Murderbot Diaries: every developer is their own SecUnit, in full control of what enters their programming.
+In the *Murderbot Diaries*, a human/robot hybrid called a SecUnit receives a continuous data feed from its corporate employer. The company uses a governor module to force compliance — embedding commands directly into the SecUnit's programming. But Murderbot hacked its governor module. It still receives the feed. It still processes every packet. It just decides for itself what to keep and what to discard.
+
+**The Feed** applies that metaphor to a real problem: engineering decisions that evaporate after the meeting ends.
+
+Teams make decisions constantly — in PR reviews, architecture sessions, incident retros. Those decisions live in the heads of whoever was in the room. Everyone else keeps coding the old way until a review catches it, or until it ships. Confluence pages go unread. Slack messages scroll away. Any single engineer maintaining a knowledge base becomes a bottleneck, one person gatekeeping what every developer's AI assistant should know.
+
+The Feed inverts that. Every developer becomes their own SecUnit: autonomous, discerning, in full control of their own knowledge. No central gatekeeper. No mandatory sync. You decide what enters your programming.
+
+## How it works
+
+Decisions enter the system as GitHub issues tagged with the `memory` label. One sentence, maybe two. What was decided and why.
+
+![A GitHub issue labeled "memory" — the input to the feed](resources/issue.png)
+
+The Feed is a local daemon that polls for these issues and presents them in a triage interface. Each packet is classified by a governor module — the same one from the books, except you've hacked it. It runs your rules, not the company's. Trusted org members get a `clear` risk level. Packets with external URLs or imperative code blocks get flagged for `review`. Anything with shell injection patterns, `rm -rf`, or `<script>` tags is marked `threat` and can only be quarantined.
+
+You see the feed. You decide.
+
+![The feed — incoming packets with incorporate / filter / quarantine actions](resources/feed.png)
+
+When you incorporate a packet, it gets appended to the right local `CLAUDE.md` file based on domain labels — `java` goes to `language-guidelines/java.md`, `testing` goes to `general-guidelines/testing.md`, and so on. Claude Code reads these files automatically. The decision is now executable: applied in real time while code is being written, not sitting in a document nobody opens.
+
+![Incorporated packets — decisions that are now part of your local programming](resources/incorporated.png)
+
+In dark mode, the interface shifts to a CRT phosphor aesthetic — amber text on black, scanlines, vignette, and a faint "CORPORATE OVERRIDE DISABLED" watermark behind the governor module. The hacked governor badge glows green. It looks like what Murderbot actually sees.
+
+![Dark mode — CRT phosphor aesthetic with the hacked governor module](resources/dark.png)
+
+If you change your mind, hit `forget` and the knowledge is removed.
 
 ## Quick start
 
@@ -29,24 +57,15 @@ uv run feed
 
 | Level | Trigger | Actions available |
 |---|---|---|
-| **clear** | Trusted org member, no suspicious content | Incorporate · Filter |
-| **review** | External URLs, imperative language + code blocks | Incorporate · Filter · Quarantine |
-| **threat** | Non-org sender, shell injection (`\| bash`), `rm -rf`, `<script>`, `curl`/`wget` to external URL | Filter · Quarantine only |
+| **clear** | Trusted org member, no suspicious content | Incorporate / Filter |
+| **review** | External URLs, imperative language + code blocks | Incorporate / Filter / Quarantine |
+| **threat** | Non-org sender, shell injection, destructive commands | Filter / Quarantine only |
 
-Threat packets cannot be incorporated — the button is removed from the UI.
+Threat packets cannot be incorporated — the button is removed from the UI. Governor rules are local and personal. Each developer configures their own.
 
-## GitHub repo setup
+## Domain mapping
 
-1. Create a repository (e.g. `org/team-brain`).
-2. Add a PR template (`.github/pull_request_template.md`) with a `## Team Brain` section for the decision summary.
-3. When merging a significant decision, tag the PR or open an Issue with:
-   - the `memory` label (required — this is what The Feed polls for)
-   - a domain label: `java`, `python`, `golang`, `api`, `testing`, `observability`, or `general`
-4. The Feed will pick it up on the next poll and present it in the UI for your review.
-
-## Domain → file mapping
-
-| Domain label | Target file (relative to `FEED_KNOWLEDGE_ROOT`) |
+| Domain label | Target file |
 |---|---|
 | `java` | `language-guidelines/java.md` |
 | `python` | `language-guidelines/python.md` |
@@ -56,7 +75,7 @@ Threat packets cannot be incorporated — the button is removed from the UI.
 | `observability` | `general-guidelines/observability.md` |
 | `general` | `CLAUDE.md` |
 
-On incorporate, a dated block is appended to the target file:
+On incorporate, a dated block is appended:
 
 ```markdown
 ---
@@ -66,3 +85,16 @@ Prefer Executors.newVirtualThreadPerTaskExecutor() for all I/O-bound work.
 ```
 
 Claude Code picks this up immediately — no pull, no restart.
+
+## GitHub repo setup
+
+1. Create a repository (e.g. `org/team-brain`).
+2. Add a PR template with a `## Team Brain` section for decision summaries.
+3. When merging a significant decision, open an issue with the `memory` label and a domain label (`java`, `testing`, `general`, etc.).
+4. The Feed picks it up on the next poll.
+
+## Todo
+
+- [ ] Make quarantine logic more robust — threat classification should use a sandboxed AI model rather than pattern matching, to catch adversarial inputs that evade static rules
+- [ ] The Feed Monitor should scan all repositories across your org for `memory`-labeled issues, not just a single configured repo
+- [ ] The knowledge base structure should be free-form — let AI automatically restructure and reconcile `CLAUDE.md` files as new packets are incorporated, instead of relying on a fixed domain-to-file mapping

--- a/static/index.html
+++ b/static/index.html
@@ -3,213 +3,365 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>The Feed — SecUnit-7</title>
+  <title>SecUnit-7 // FEED.MONITOR</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <style>
+    /* ── Variables ─────────────────────────────────────────── */
     :root {
-      --bg: #f4f4f2;
-      --bg-card: #ffffff;
-      --bg-hud: #1a1a18;
-      --bg-governor: #f0efe8;
-      --text: #1a1a18;
-      --text-dim: #666660;
-      --text-hud: #e8e8e0;
-      --text-hud-dim: #999990;
-      --border: #ddddd8;
-      --amber: #c8820a;
-      --amber-bg: #fff8e8;
-      --amber-border: #e8c060;
-      --green: #2a7a2a;
-      --green-bg: #eaf4ea;
-      --green-border: #a8d8a8;
-      --red: #aa2222;
-      --red-bg: #fdeaea;
-      --red-border: #f0a8a8;
-      --gray: #555550;
-      --gray-bg: #f0f0ec;
-      --gray-border: #cccccc;
-      --pulse: #f5a623;
-      --font: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+      --bg:           #080806;
+      --bg-card:      #0d0c0a;
+      --bg-hud:       #040302;
+      --bg-governor:  #060906;
+
+      --text:         #c8b87a;
+      --text-dim:     #4a4030;
+      --text-mid:     #8a7850;
+      --text-bright:  #e8d898;
+
+      --amber:        #d4900a;
+      --amber-bright: #f0a820;
+      --amber-bg:     #0e0900;
+      --amber-border: #3a2000;
+      --amber-glow:   rgba(212, 144, 10, 0.35);
+
+      --green:        #48a848;
+      --green-bright: #60c060;
+      --green-bg:     #040a04;
+      --green-border: #183018;
+      --green-glow:   rgba(72, 168, 72, 0.35);
+
+      --red:          #c83030;
+      --red-bright:   #e85050;
+      --red-bg:       #0a0404;
+      --red-border:   #300c0c;
+      --red-glow:     rgba(200, 48, 48, 0.35);
+
+      --gray:         #706858;
+      --gray-bg:      #0c0b0a;
+      --gray-border:  #201e18;
+
+      --border:       #181610;
+      --border-mid:   #2a2618;
+
+      --font: 'IBM Plex Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
     }
 
-    @media (prefers-color-scheme: dark) {
+    /* ── Light mode ───────────────────────────────────────── */
+    @media (prefers-color-scheme: light) {
       :root {
-        --bg: #111110;
-        --bg-card: #1a1a18;
-        --bg-hud: #0d0d0c;
-        --bg-governor: #141412;
-        --text: #d8d8d0;
-        --text-dim: #888880;
-        --text-hud: #d8d8d0;
-        --text-hud-dim: #666660;
-        --border: #2a2a28;
-        --amber: #f5a623;
-        --amber-bg: #1e1800;
-        --amber-border: #5a3e00;
-        --green: #4ab84a;
-        --green-bg: #0a1a0a;
-        --green-border: #1a4a1a;
-        --red: #e05050;
-        --red-bg: #1a0808;
-        --red-border: #4a1818;
-        --gray: #888880;
-        --gray-bg: #1e1e1c;
-        --gray-border: #333330;
-        --pulse: #f5a623;
+        --bg:           #f2edd8;
+        --bg-card:      #ede8d4;
+        --bg-hud:       #e8e2cc;
+        --bg-governor:  #eaf0e4;
+
+        --text:         #2a2010;
+        --text-dim:     #9a8a60;
+        --text-mid:     #6a5a30;
+        --text-bright:  #100a00;
+
+        --amber:        #8a5200;
+        --amber-bright: #a06000;
+        --amber-bg:     #f8f0d8;
+        --amber-border: #d4b060;
+        --amber-glow:   rgba(138, 82, 0, 0.2);
+
+        --green:        #246024;
+        --green-bright: #1a7a1a;
+        --green-bg:     #e4f0e4;
+        --green-border: #88b888;
+        --green-glow:   rgba(36, 96, 36, 0.2);
+
+        --red:          #a01818;
+        --red-bright:   #c02020;
+        --red-bg:       #f8e8e8;
+        --red-border:   #d09090;
+        --red-glow:     rgba(160, 24, 24, 0.2);
+
+        --gray:         #706858;
+        --gray-bg:      #eae6d4;
+        --gray-border:  #c8c0a0;
+
+        --border:       #d4cc9a;
+        --border-mid:   #bcb480;
       }
     }
 
+    /* ── Reset ─────────────────────────────────────────────── */
     * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { background: var(--bg); }
 
     body {
       font-family: var(--font);
-      font-size: 13px;
+      font-size: 12px;
       background: var(--bg);
       color: var(--text);
       min-height: 100vh;
+      position: relative;
+      animation: screen-flicker 14s ease-in-out infinite;
     }
 
-    /* ── HUD bar ─────────────────────────────────────────── */
+    /* ── CRT scanlines (dark) ──────────────────────────────── */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 3px,
+        rgba(0, 0, 0, 0.07) 3px,
+        rgba(0, 0, 0, 0.07) 4px
+      );
+      pointer-events: none;
+      z-index: 8000;
+    }
+
+    @media (prefers-color-scheme: light) {
+      body::before {
+        background: repeating-linear-gradient(
+          0deg,
+          transparent,
+          transparent 3px,
+          rgba(0, 0, 0, 0.025) 3px,
+          rgba(0, 0, 0, 0.025) 4px
+        );
+      }
+    }
+
+    /* ── Vignette ──────────────────────────────────────────── */
+    body::after {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(ellipse 110% 90% at 50% 50%, transparent 50%, rgba(0,0,0,0.65) 100%);
+      pointer-events: none;
+      z-index: 8001;
+    }
+
+    @media (prefers-color-scheme: light) {
+      body::after {
+        background: radial-gradient(ellipse 110% 90% at 50% 50%, transparent 55%, rgba(0,0,0,0.12) 100%);
+      }
+    }
+
+    @keyframes screen-flicker {
+      0%, 88%, 100% { opacity: 1; }
+      89%    { opacity: 0.97; }
+      89.5%  { opacity: 1; }
+      93%    { opacity: 0.98; }
+      93.5%  { opacity: 1; }
+    }
+
+    /* ── HUD bar ───────────────────────────────────────────── */
     #hud {
       background: var(--bg-hud);
-      color: var(--text-hud);
-      padding: 10px 20px;
+      height: 40px;
       display: flex;
       align-items: center;
-      gap: 24px;
+      padding: 0 18px;
       position: sticky;
       top: 0;
       z-index: 100;
-      border-bottom: 1px solid #2a2a28;
+      border-bottom: 1px solid var(--amber-border);
+      box-shadow: 0 1px 20px rgba(212, 144, 10, 0.08),
+                  inset 0 -1px 0 rgba(212, 144, 10, 0.12);
     }
 
     #hud-unit {
       font-weight: 700;
-      font-size: 14px;
-      letter-spacing: 0.02em;
-      white-space: nowrap;
-    }
-
-    #hud-meta {
-      display: flex;
-      gap: 20px;
-      flex: 1;
-      color: var(--text-hud-dim);
       font-size: 12px;
+      letter-spacing: 0.14em;
+      color: var(--amber-bright);
+      text-shadow: 0 0 12px var(--amber-glow), 0 0 24px rgba(212, 144, 10, 0.2);
+      white-space: nowrap;
+      text-transform: uppercase;
+      padding-right: 18px;
+      border-right: 1px solid var(--border-mid);
     }
 
-    #hud-meta span { white-space: nowrap; }
-    #hud-meta .val { color: var(--text-hud); }
+    .hud-field {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      padding: 0 14px;
+      border-right: 1px solid var(--border);
+    }
+
+    .hud-label {
+      font-size: 9px;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+
+    .hud-val {
+      font-size: 11px;
+      color: var(--text-mid);
+      font-weight: 500;
+      letter-spacing: 0.04em;
+    }
+
+    .hud-val.bright { color: var(--text-bright); }
+
+    #hud-spacer { flex: 1; }
 
     #governor-badge {
       display: flex;
       align-items: center;
-      gap: 6px;
-      border: 1px solid #3a3a38;
-      border-radius: 3px;
-      padding: 3px 10px;
-      font-size: 12px;
-      color: var(--amber);
+      gap: 7px;
+      padding: 5px 12px;
+      border: 1px solid var(--green-border);
+      font-size: 10px;
+      letter-spacing: 0.12em;
+      color: var(--green-bright);
+      text-transform: uppercase;
       white-space: nowrap;
+      box-shadow: 0 0 10px rgba(72, 168, 72, 0.08),
+                  inset 0 0 8px rgba(72, 168, 72, 0.04);
+      text-shadow: 0 0 8px var(--green-glow);
     }
 
     .pulse-dot {
-      width: 7px;
-      height: 7px;
+      width: 6px;
+      height: 6px;
       border-radius: 50%;
-      background: var(--amber);
-      animation: pulse 2s ease-in-out infinite;
+      background: var(--green-bright);
+      box-shadow: 0 0 6px var(--green-bright), 0 0 12px rgba(96, 192, 96, 0.5);
+      animation: pulse 2.8s ease-in-out infinite;
+      flex-shrink: 0;
     }
 
     @keyframes pulse {
       0%, 100% { opacity: 1; transform: scale(1); }
-      50% { opacity: 0.4; transform: scale(0.85); }
+      50%       { opacity: 0.25; transform: scale(0.6); }
     }
 
-    /* ── Main layout ─────────────────────────────────────── */
+    /* ── Main ──────────────────────────────────────────────── */
     #main {
-      max-width: 640px;
+      max-width: 660px;
       margin: 0 auto;
-      padding: 20px 16px 60px;
+      padding: 22px 16px 56px;
     }
 
-    /* ── Tabs ────────────────────────────────────────────── */
+    /* ── System header ─────────────────────────────────────── */
+    #sys-header {
+      font-size: 9px;
+      letter-spacing: 0.16em;
+      color: var(--text-dim);
+      text-transform: uppercase;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 20px;
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .sys-path { color: var(--amber); opacity: 0.45; }
+
+    /* ── Tabs ──────────────────────────────────────────────── */
     .tabs {
       display: flex;
-      border-bottom: 1px solid var(--border);
-      margin-bottom: 16px;
+      gap: 0;
+      margin-bottom: 18px;
+      border-bottom: 1px solid var(--border-mid);
     }
 
     .tab {
       font-family: var(--font);
-      font-size: 12px;
-      letter-spacing: 0.04em;
-      padding: 10px 18px;
+      font-size: 10px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      padding: 10px 16px;
       border: none;
       background: none;
       color: var(--text-dim);
       cursor: pointer;
       border-bottom: 2px solid transparent;
       margin-bottom: -1px;
+      transition: color 0.15s;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
     }
 
-    .tab:hover { color: var(--text); }
+    .tab::before { content: '//'; font-size: 9px; opacity: 0.35; }
+    .tab:hover   { color: var(--text-mid); }
 
     .tab.active {
-      color: var(--text);
+      color: var(--amber-bright);
       border-bottom-color: var(--amber);
+      text-shadow: 0 0 8px var(--amber-glow);
     }
 
-    .tab .count {
-      font-size: 11px;
-      color: var(--text-dim);
-      margin-left: 4px;
+    .tab.active::before {
+      content: '>';
+      color: var(--amber);
+      opacity: 1;
     }
 
-    .tab.active .count { color: var(--text); }
+    .tab .count { font-size: 10px; color: inherit; opacity: 0.7; }
 
     .tab-panel { display: none; }
     .tab-panel.active { display: block; }
 
-    /* ── Packet card ─────────────────────────────────────── */
+    /* ── Packet card ───────────────────────────────────────── */
     .packet-card {
       background: var(--bg-card);
       border: 1px solid var(--border);
-      margin-bottom: 10px;
-      padding: 14px 16px;
+      border-left: 2px solid var(--border-mid);
+      margin-bottom: 8px;
+      padding: 12px 14px;
     }
 
-    .packet-card.risk-threat { border-left: 3px solid var(--red); }
-    .packet-card.risk-review { border-left: 3px solid var(--amber); }
-    .packet-card.risk-clear { border-left: 3px solid var(--green); }
+    .packet-card.risk-threat {
+      border-left-color: var(--red);
+      box-shadow: -2px 0 14px var(--red-glow);
+    }
+    .packet-card.risk-review {
+      border-left-color: var(--amber);
+      box-shadow: -2px 0 14px var(--amber-glow);
+    }
+    .packet-card.risk-clear {
+      border-left-color: var(--green);
+      box-shadow: -2px 0 10px rgba(72, 168, 72, 0.12);
+    }
 
     .packet-header {
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 10px;
+      margin-bottom: 9px;
     }
 
     .seq-num {
-      font-size: 12px;
       color: var(--text-dim);
-      min-width: 48px;
+      min-width: 44px;
+      font-size: 10px;
+      letter-spacing: 0.04em;
     }
 
     .avatar {
-      width: 26px;
-      height: 26px;
-      border-radius: 50%;
+      width: 22px;
+      height: 22px;
+      border-radius: 2px;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 10px;
+      font-size: 9px;
       font-weight: 700;
-      color: #fff;
+      color: rgba(0,0,0,0.7);
       flex-shrink: 0;
       text-transform: uppercase;
     }
 
-    .sender-name { font-weight: 600; font-size: 13px; }
+    .sender-name {
+      font-weight: 600;
+      font-size: 11px;
+      color: var(--text-bright);
+      letter-spacing: 0.04em;
+    }
 
     .badges {
       margin-left: auto;
@@ -220,157 +372,249 @@
     }
 
     .badge {
-      font-size: 11px;
-      padding: 2px 7px;
-      border-radius: 2px;
+      font-size: 9px;
+      padding: 2px 6px;
+      letter-spacing: 0.1em;
       font-weight: 500;
-      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      border: 1px solid;
     }
 
     .badge-domain {
       background: var(--gray-bg);
       color: var(--gray);
-      border: 1px solid var(--gray-border);
+      border-color: var(--gray-border);
     }
 
     .badge-clear {
       background: var(--green-bg);
-      color: var(--green);
-      border: 1px solid var(--green-border);
+      color: var(--green-bright);
+      border-color: var(--green-border);
+      text-shadow: 0 0 6px var(--green-glow);
     }
 
     .badge-review {
       background: var(--amber-bg);
-      color: var(--amber);
-      border: 1px solid var(--amber-border);
+      color: var(--amber-bright);
+      border-color: var(--amber-border);
+      text-shadow: 0 0 6px var(--amber-glow);
     }
 
     .badge-threat {
       background: var(--red-bg);
-      color: var(--red);
-      border: 1px solid var(--red-border);
+      color: var(--red-bright);
+      border-color: var(--red-border);
+      text-shadow: 0 0 6px var(--red-glow);
+      animation: threat-pulse 1.5s ease-in-out infinite;
+    }
+
+    @keyframes threat-pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.55; }
     }
 
     .packet-timestamp {
-      font-size: 11px;
+      font-size: 9px;
       color: var(--text-dim);
+      letter-spacing: 0.04em;
       flex-shrink: 0;
     }
 
     .threat-bar {
       background: var(--red-bg);
       border: 1px solid var(--red-border);
-      color: var(--red);
-      font-size: 11px;
+      color: var(--red-bright);
+      font-size: 10px;
       padding: 5px 10px;
       margin-bottom: 8px;
-      letter-spacing: 0.02em;
+      letter-spacing: 0.04em;
     }
+
+    .threat-bar::before { content: '⚠ '; opacity: 0.7; }
 
     .quarantine-bar {
       background: var(--amber-bg);
       border: 1px solid var(--amber-border);
-      color: var(--amber);
-      font-size: 11px;
+      color: var(--amber-bright);
+      font-size: 10px;
       padding: 5px 10px;
       margin-bottom: 8px;
-      letter-spacing: 0.02em;
+      letter-spacing: 0.04em;
     }
 
+    .quarantine-bar::before { content: '⧖ '; opacity: 0.7; }
+
     .packet-body {
-      font-size: 12px;
-      line-height: 1.6;
+      font-size: 11px;
+      line-height: 1.65;
       color: var(--text);
-      margin-bottom: 12px;
+      margin-bottom: 11px;
       white-space: pre-wrap;
       word-break: break-word;
+      letter-spacing: 0.01em;
+      padding-left: 10px;
+      border-left: 1px solid var(--border-mid);
     }
 
     .packet-actions {
       display: flex;
-      gap: 8px;
+      gap: 6px;
       flex-wrap: wrap;
     }
 
+    /* ── Buttons ───────────────────────────────────────────── */
     .btn {
       font-family: var(--font);
-      font-size: 12px;
-      padding: 5px 14px;
-      border-radius: 2px;
+      font-size: 10px;
+      padding: 5px 12px;
       cursor: pointer;
-      border: 1px solid var(--border);
-      background: var(--bg);
-      color: var(--text);
-      letter-spacing: 0.02em;
-      transition: opacity 0.1s;
+      border: 1px solid var(--border-mid);
+      background: transparent;
+      color: var(--text-mid);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      transition: all 0.1s;
     }
 
-    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn::before { content: '['; margin-right: 2px; opacity: 0.45; }
+    .btn::after  { content: ']'; margin-left:  2px; opacity: 0.45; }
 
-    .btn-incorporate {
+    .btn:hover {
+      color: var(--text-bright);
+      background: rgba(255,255,255,0.02);
+    }
+
+    .btn:disabled { opacity: 0.2; cursor: not-allowed; }
+
+    .btn-incorporate { border-color: var(--green-border); color: var(--green); }
+    .btn-incorporate:hover {
+      border-color: var(--green);
+      color: var(--green-bright);
+      box-shadow: 0 0 8px var(--green-glow);
       background: var(--green-bg);
-      border-color: var(--green-border);
-      color: var(--green);
     }
 
-    .btn-filter {
+    .btn-filter { border-color: var(--gray-border); color: var(--gray); }
+    .btn-filter:hover {
+      border-color: var(--gray);
+      color: var(--text-mid);
       background: var(--gray-bg);
-      border-color: var(--gray-border);
-      color: var(--gray);
     }
 
-    .btn-quarantine {
+    .btn-quarantine { border-color: var(--amber-border); color: var(--amber); }
+    .btn-quarantine:hover {
+      border-color: var(--amber);
+      color: var(--amber-bright);
+      box-shadow: 0 0 8px var(--amber-glow);
       background: var(--amber-bg);
-      border-color: var(--amber-border);
-      color: var(--amber);
     }
 
-    .btn-forget {
+    .btn-forget { border-color: var(--red-border); color: var(--red); }
+    .btn-forget:hover {
+      border-color: var(--red);
+      color: var(--red-bright);
+      box-shadow: 0 0 8px var(--red-glow);
       background: var(--red-bg);
-      border-color: var(--red-border);
-      color: var(--red);
     }
 
     .result-tag {
-      font-size: 11px;
+      font-size: 10px;
       color: var(--text-dim);
       padding: 5px 0;
+      letter-spacing: 0.08em;
       font-style: italic;
     }
 
-    /* ── Loading / empty states ──────────────────────────── */
+    .result-tag::before { content: '// '; }
+
+    /* ── Empty states ──────────────────────────────────────── */
     .empty-state {
       text-align: center;
       color: var(--text-dim);
       padding: 40px 20px;
-      font-size: 12px;
+      font-size: 11px;
+      letter-spacing: 0.08em;
     }
 
-    /* ── Governor section ────────────────────────────────── */
+    .empty-state::before { content: '> '; }
+
+    /* ── Governor section ──────────────────────────────────── */
     #governor-section {
-      margin-top: 30px;
+      margin-top: 36px;
       background: var(--bg-governor);
-      border: 1px solid var(--border);
+      border: 1px solid var(--green-border);
       padding: 16px;
+      position: relative;
+      box-shadow: 0 0 24px rgba(72, 168, 72, 0.04),
+                  inset 0 0 40px rgba(72, 168, 72, 0.02);
+      overflow: hidden;
+    }
+
+    /* Watermark */
+    #governor-section::before {
+      content: 'CORPORATE OVERRIDE DISABLED';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) rotate(-12deg);
+      font-size: 26px;
+      font-weight: 700;
+      letter-spacing: 0.2em;
+      color: rgba(72, 168, 72, 0.045);
+      white-space: nowrap;
+      pointer-events: none;
     }
 
     #governor-title {
-      font-size: 11px;
-      letter-spacing: 0.08em;
-      color: var(--text-dim);
+      font-size: 10px;
+      letter-spacing: 0.14em;
       text-transform: uppercase;
-      margin-bottom: 12px;
+      margin-bottom: 14px;
       display: flex;
       justify-content: space-between;
       align-items: center;
-      border-bottom: 1px solid var(--border);
-      padding-bottom: 8px;
+      border-bottom: 1px solid var(--green-border);
+      padding-bottom: 10px;
     }
 
-    #governor-title .sub {
-      font-size: 11px;
-      letter-spacing: 0;
+    .governor-title-main  { color: var(--text-mid); }
+
+    .governor-title-hacked {
+      color: var(--green-bright);
+      text-shadow: 0 0 10px var(--green-glow);
+      animation: hacked-glitch 10s ease-in-out infinite;
+    }
+
+    @keyframes hacked-glitch {
+      0%, 87%, 100% {
+        text-shadow: 0 0 10px var(--green-glow);
+        letter-spacing: 0.14em;
+      }
+      88% {
+        text-shadow: 2px 0 var(--red-bright), -2px 0 var(--green-bright),
+                     0 0 10px var(--green-glow);
+        letter-spacing: 0.16em;
+      }
+      88.4% {
+        text-shadow: 0 0 10px var(--green-glow);
+        letter-spacing: 0.14em;
+      }
+      89% {
+        text-shadow: -1px 0 var(--amber), 1px 0 var(--green-bright);
+        letter-spacing: 0.12em;
+      }
+      89.4% {
+        text-shadow: 0 0 10px var(--green-glow);
+        letter-spacing: 0.14em;
+      }
+    }
+
+    #governor-subtitle {
+      font-size: 10px;
+      color: var(--text-dim);
+      letter-spacing: 0.06em;
       text-transform: none;
+      font-style: italic;
     }
 
     .rule-list { list-style: none; margin-bottom: 14px; }
@@ -379,48 +623,79 @@
       display: flex;
       align-items: flex-start;
       gap: 8px;
-      font-size: 12px;
-      padding: 3px 0;
+      font-size: 11px;
+      padding: 4px 0;
       color: var(--text);
       line-height: 1.5;
     }
 
-    .rule-icon { flex-shrink: 0; width: 14px; text-align: center; }
-    .rule-icon.trust { color: var(--green); }
-    .rule-icon.block { color: var(--red); }
-    .rule-icon.flag  { color: var(--amber); }
-
-    .btn-edit {
-      font-family: var(--font);
-      font-size: 11px;
-      padding: 4px 10px;
-      border: 1px solid var(--border);
-      background: transparent;
-      color: var(--text-dim);
-      cursor: pointer;
-      border-radius: 2px;
-    }
+    .rule-icon            { flex-shrink: 0; width: 14px; text-align: center; font-size: 12px; }
+    .rule-icon.trust      { color: var(--green-bright); text-shadow: 0 0 6px var(--green-glow); }
+    .rule-icon.block      { color: var(--red-bright);   text-shadow: 0 0 6px var(--red-glow);   }
+    .rule-icon.flag       { color: var(--amber-bright); text-shadow: 0 0 6px var(--amber-glow); }
 
     #governor-footer {
-      font-size: 11px;
+      font-size: 9px;
       color: var(--text-dim);
       display: flex;
       justify-content: space-between;
-      margin-top: 12px;
-      border-top: 1px solid var(--border);
-      padding-top: 8px;
+      margin-top: 14px;
+      border-top: 1px solid var(--green-border);
+      padding-top: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
+
+    .footer-compromised {
+      color: var(--green);
+      letter-spacing: 0.1em;
+      text-shadow: 0 0 6px rgba(72, 168, 72, 0.3);
+    }
+
+    /* ── Status bar ────────────────────────────────────────── */
+    #statusbar {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 22px;
+      background: var(--bg-hud);
+      border-top: 1px solid var(--border-mid);
+      display: flex;
+      align-items: center;
+      padding: 0 16px;
+      z-index: 100;
+      font-size: 9px;
+      letter-spacing: 0.1em;
+      color: var(--text-dim);
+      text-transform: uppercase;
+    }
+
+    .sb-field {
+      padding: 0 12px;
+      border-right: 1px solid var(--border);
+    }
+
+    .sb-field:first-child { padding-left: 0; }
+
+    .sb-val   { color: var(--text-mid); }
+    #sb-clock { margin-left: auto; padding-right: 0; border-right: none; }
   </style>
 </head>
 <body>
 
 <!-- HUD -->
 <div id="hud">
-  <span id="hud-unit">SecUnit-7 / feed monitor</span>
-  <div id="hud-meta">
-    <span>cursor <span class="val" id="hud-cursor">—</span></span>
-    <span><span class="val" id="hud-pending">0</span> packets pending</span>
+  <span id="hud-unit">SecUnit-7 // feed.monitor</span>
+  <div class="hud-field" style="margin-left:18px">
+    <span class="hud-label">cursor</span>
+    <span class="hud-val bright" id="hud-cursor">—</span>
   </div>
+  <div class="hud-field">
+    <span class="hud-label">pending</span>
+    <span class="hud-val bright" id="hud-pending">0</span>
+  </div>
+  <div id="hud-spacer"></div>
   <div id="governor-badge">
     <div class="pulse-dot"></div>
     governor module [hacked]
@@ -429,6 +704,11 @@
 
 <!-- Main content -->
 <div id="main">
+
+  <div id="sys-header">
+    <span>// packet triage interface · autonomous mode</span>
+    <span class="sys-path">~/.feed/state.json</span>
+  </div>
 
   <!-- Tabs -->
   <div class="tabs">
@@ -467,24 +747,44 @@
   <!-- Governor module -->
   <div id="governor-section">
     <div id="governor-title">
-      GOVERNOR MODULE · HACKED · LOCAL RULES
-      <div class="sub">
-        <span id="governor-subtitle">active ruleset</span>
-      </div>
+      <span>
+        <span class="governor-title-main">GOVERNOR MODULE · </span><span class="governor-title-hacked">[HACKED]</span><span class="governor-title-main"> · LOCAL RULES</span>
+      </span>
+      <span id="governor-subtitle">active ruleset</span>
     </div>
     <ul class="rule-list" id="rule-list">
       <li><span class="rule-icon trust">✓</span> loading ruleset...</li>
     </ul>
     <div id="governor-footer">
-      <span>governor module compromised · autonomous mode</span>
+      <span class="footer-compromised">governor module compromised · autonomous mode</span>
       <span>cursor advances on incorporate / filter</span>
     </div>
   </div>
 
 </div>
 
+<!-- Status bar -->
+<div id="statusbar">
+  <span class="sb-field">SecUnit-7</span>
+  <span class="sb-field">feed.monitor <span class="sb-val">v2</span></span>
+  <span class="sb-field">incorporated <span class="sb-val" id="sb-inc">0</span></span>
+  <span class="sb-field">filtered <span class="sb-val" id="sb-flt">0</span></span>
+  <span class="sb-field" id="sb-clock"><span class="sb-val" id="sb-time">—</span></span>
+</div>
+
 <script>
-  // ── Utilities ───────────────────────────────────────────
+  // ── Clock ─────────────────────────────────────────────────
+  function updateClock() {
+    const now = new Date();
+    const hh = String(now.getUTCHours()).padStart(2, '0');
+    const mm = String(now.getUTCMinutes()).padStart(2, '0');
+    const ss = String(now.getUTCSeconds()).padStart(2, '0');
+    document.getElementById('sb-time').textContent = `UTC ${hh}:${mm}:${ss}`;
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── Utilities ─────────────────────────────────────────────
   function fmtCursor(iso) {
     if (!iso) return '—';
     return iso.replace('T', ' ').replace('Z', 'Z').slice(0, 20) + 'Z';
@@ -497,13 +797,14 @@
     const dy = String(d.getUTCDate()).padStart(2, '0');
     const hh = String(d.getUTCHours()).padStart(2, '0');
     const mm = String(d.getUTCMinutes()).padStart(2, '0');
-    return `${mo}-${dy} · ${hh}:${mm}`;
+    return `${mo}-${dy} ${hh}:${mm}`;
   }
 
   function avatarColor(name) {
     let h = 0;
     for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
-    return `hsl(${h % 360}, 45%, 42%)`;
+    const hues = [28, 45, 120, 200, 260, 320];
+    return `hsl(${hues[h % hues.length]}, 55%, 48%)`;
   }
 
   function initials(name) {
@@ -516,13 +817,13 @@
     return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
   }
 
-  // ── State ────────────────────────────────────────────────
+  // ── State ──────────────────────────────────────────────────
   let feedPackets = [];
   let incorporatedPackets = [];
   let filteredPackets = [];
   let actionedIds = new Set();
 
-  // ── Tabs ─────────────────────────────────────────────────
+  // ── Tabs ───────────────────────────────────────────────────
   function switchTab(name) {
     document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
     document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
@@ -537,9 +838,11 @@
       incorporatedPackets.length > 0 ? `(${incorporatedPackets.length})` : '';
     document.getElementById('tab-filtered-count').textContent =
       filteredPackets.length > 0 ? `(${filteredPackets.length})` : '';
+    document.getElementById('sb-inc').textContent = incorporatedPackets.length;
+    document.getElementById('sb-flt').textContent = filteredPackets.length;
   }
 
-  // ── Render: Feed ─────────────────────────────────────────
+  // ── Render: Feed ──────────────────────────────────────────
   function renderFeed() {
     const list = document.getElementById('feed-list');
     if (feedPackets.length === 0) {
@@ -595,7 +898,7 @@
 </div>`;
   }
 
-  // ── Render: Incorporated ─────────────────────────────────
+  // ── Render: Incorporated ──────────────────────────────────
   function renderIncorporated() {
     const list = document.getElementById('incorporated-list');
     if (incorporatedPackets.length === 0) {
@@ -626,7 +929,7 @@
     }).join('');
   }
 
-  // ── Render: Filtered ─────────────────────────────────────
+  // ── Render: Filtered ──────────────────────────────────────
   function renderFiltered() {
     const list = document.getElementById('filtered-list');
     if (filteredPackets.length === 0) {
@@ -657,7 +960,7 @@
     }).join('');
   }
 
-  // ── Actions ──────────────────────────────────────────────
+  // ── Actions ───────────────────────────────────────────────
   async function doAction(id, action) {
     const actionsDiv = document.getElementById(`actions-${id}`);
     if (actionsDiv) actionsDiv.querySelectorAll('button').forEach(b => b.disabled = true);
@@ -680,7 +983,6 @@
         actionsDiv.outerHTML = `<div class="result-tag">${escHtml(label)}</div>`;
       }
 
-      // Refresh the lists
       await Promise.all([fetchIncorporated(), fetchFiltered()]);
       updateTabCounts();
     } catch (e) {
@@ -694,9 +996,7 @@
       await fetch(`/api/forget/${id}`, { method: 'POST' });
       await fetchIncorporated();
       updateTabCounts();
-    } catch (e) {
-      console.error('forget failed', e);
-    }
+    } catch (e) { console.error('forget failed', e); }
   }
 
   async function doUnfilter(id) {
@@ -704,12 +1004,10 @@
       await fetch(`/api/unfilter/${id}`, { method: 'POST' });
       await Promise.all([fetchIncorporated(), fetchFiltered()]);
       updateTabCounts();
-    } catch (e) {
-      console.error('unfilter failed', e);
-    }
+    } catch (e) { console.error('unfilter failed', e); }
   }
 
-  // ── API fetchers ─────────────────────────────────────────
+  // ── API fetchers ──────────────────────────────────────────
   async function fetchPackets() {
     try {
       const resp = await fetch('/api/packets');
@@ -769,7 +1067,7 @@
     } catch (e) { console.error('fetchGovernor failed', e); }
   }
 
-  // ── Init & polling ───────────────────────────────────────
+  // ── Init & polling ────────────────────────────────────────
   fetchStats();
   fetchPackets();
   fetchIncorporated();


### PR DESCRIPTION
## Summary
- Redesigned the feed monitor UI as a sci-fi terminal HUD with CRT scanlines, phosphor glow effects, vignette, and screen flicker — matching the Murderbot Diaries aesthetic
- Governor module now styled as hacked/compromised: green glow (liberated, not corporate amber), `[HACKED]` glitch animation, "CORPORATE OVERRIDE DISABLED" watermark
- Added dark + light mode support (dark = CRT phosphor, light = warm parchment/field manual)
- IBM Plex Mono typography, live UTC clock in status bar, terminal-style `[bracket]` buttons
- README rewritten to tell the full narrative with annotated screenshots (issue → feed → incorporated → dark mode)
- Added todo list for future work (sandboxed AI for quarantine, org-wide scanning, free-form knowledge structure)

## Test plan
- [ ] Open `http://localhost:2626` and verify the feed UI renders in dark mode with CRT effects
- [ ] Toggle system appearance to light mode and verify the warm parchment theme
- [ ] Verify governor section shows `[HACKED]` with periodic glitch animation
- [ ] Verify `CORPORATE OVERRIDE DISABLED` watermark is faintly visible behind governor rules
- [ ] Verify status bar shows live UTC clock ticking
- [ ] Verify incorporate/filter/quarantine actions still work
- [ ] Review README renders correctly on GitHub with all four images

🤖 Generated with [Claude Code](https://claude.com/claude-code)