### PR TITLE
Replace GitHub category labels with TF-IDF content routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	uv run pytest

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You see the feed. You decide.
 
 ![The feed — incoming packets with incorporate / filter / quarantine actions](resources/feed.png)
 
-When you incorporate a packet, it gets appended to the right local `CLAUDE.md` file based on domain labels — `java` goes to `language-guidelines/java.md`, `testing` goes to `general-guidelines/testing.md`, and so on. Claude Code reads these files automatically. The decision is now executable: applied in real time while code is being written, not sitting in a document nobody opens.
+When you incorporate a packet, it gets appended to the right local `CLAUDE.md` file — `language-guidelines/java.md`, `general-guidelines/testing.md`, and so on. There are no category labels in GitHub. The Feed reads the packet body and routes it by content, using TF-IDF similarity against the files already in your knowledge base. A note about Spring Boot constructor injection lands in `java.md`. A note about `async def` and pytest lands in `python.md`. A note that mentions neither — "be kind in reviews" — falls back to the catch-all `CLAUDE.md`, where the dreamer can pick it up later (see below). Claude Code reads all of these files automatically. The decision is now executable: applied in real time while code is being written, not sitting in a document nobody opens.
 
 ![Incorporated packets — decisions that are now part of your local programming](resources/incorporated.png)
 
@@ -63,9 +63,20 @@ uv run feed
 
 Threat packets cannot be incorporated — the button is removed from the UI. Governor rules are local and personal. Each developer configures their own.
 
-## Domain mapping
+## How routing works
 
-| Domain label | Target file |
+Each target file under `FEED_KNOWLEDGE_ROOT` is treated as one document in a small corpus. When a new packet arrives, The Feed:
+
+1. Tokenizes the packet body (lowercase, stopwords dropped).
+2. Builds a TF-IDF vector over the same vocabulary as the corpus.
+3. Computes cosine similarity against every target file.
+4. Routes to the highest-scoring file — unless the top score is below a confidence threshold, in which case it falls back to the catch-all `CLAUDE.md`.
+
+This is deterministic, explainable, and dependency-free (no embeddings, no LLM call in the hot path). A packet mentioning `FastAPI`, `Pydantic`, and `uvicorn` is drawn to `python.md` because those rare tokens already live there. A packet with no meaningful overlap is routed to the catch-all rather than guessed at.
+
+To keep cold start honest — when a target file is empty or missing — the classifier concatenates each file's live contents with a short seed vocabulary (`Spring Boot Maven Gradle…` for `java`, `FastAPI Pydantic asyncio…` for `python`, etc.). As real packets accumulate, the seeds' influence fades proportionally. The seeds live in [`src/feed/classifier.py`](src/feed/classifier.py) and can be edited per deployment.
+
+| Domain | Target file |
 |---|---|
 | `java` | `language-guidelines/java.md` |
 | `python` | `language-guidelines/python.md` |
@@ -73,7 +84,19 @@ Threat packets cannot be incorporated — the button is removed from the UI. Gov
 | `api` | `general-guidelines/specs-and-plans.md` |
 | `testing` | `general-guidelines/testing.md` |
 | `observability` | `general-guidelines/observability.md` |
-| `general` | `CLAUDE.md` |
+| `general` (catch-all) | `CLAUDE.md` |
+
+## The dreamer
+
+Ingest-time routing is intentionally simple. It handles obvious cases well and falls back to the catch-all when unsure. Over time, three kinds of drift accumulate:
+
+- Notes that landed in `CLAUDE.md` because the dreamer hadn't yet taught the classifier what they were about.
+- Notes that landed in the wrong file because the classifier only sees literal token overlap, not semantics.
+- Files that have grown long enough to deserve being split, or short-lived topics that have gone stale.
+
+The Feed expects a separate background agent — the **dreamer** — to periodically re-read the full knowledge base, re-sort packets, split or merge files, and prune decisions that no longer apply. The dreamer is not part of this daemon. It runs on its own schedule (hourly, nightly, whenever you like) against the same `FEED_KNOWLEDGE_ROOT`. The ingest path stays cheap and deterministic; the dreamer handles semantics and housekeeping out of band.
+
+Because each incorporated block carries a `<!-- feed:#N · sender · timestamp -->` header, the dreamer can always trace a decision back to its source issue when it needs to justify a move.
 
 On incorporate, a dated block is appended:
 
@@ -90,11 +113,11 @@ Claude Code picks this up immediately — no pull, no restart.
 
 1. Create a repository (e.g. `org/team-brain`).
 2. Add a PR template with a `## Team Brain` section for decision summaries.
-3. When merging a significant decision, open an issue with the `memory` label and a domain label (`java`, `testing`, `general`, etc.).
-4. The Feed picks it up on the next poll.
+3. When merging a significant decision, open an issue with the `memory` label. That's the only label the ingest path cares about — The Feed classifies the body by content, so you don't need (and should not add) category labels like `java` or `python`.
+4. The Feed picks it up on the next poll and routes it by TF-IDF similarity against your existing knowledge base.
 
 ## Todo
 
 - [ ] Make quarantine logic more robust — threat classification should use a sandboxed AI model rather than pattern matching, to catch adversarial inputs that evade static rules
 - [ ] The Feed Monitor should scan all repositories across your org for `memory`-labeled issues, not just a single configured repo
-- [ ] The knowledge base structure should be free-form — let AI automatically restructure and reconcile `CLAUDE.md` files as new packets are incorporated, instead of relying on a fixed domain-to-file mapping
+- [ ] Build the **dreamer** — a background agent that periodically re-reads `FEED_KNOWLEDGE_ROOT`, re-sorts packets the TF-IDF router got wrong, splits bloated files, and prunes stale decisions. The ingest path stays cheap and deterministic; the dreamer handles semantics and housekeeping out of band.

--- a/src/feed/classifier.py
+++ b/src/feed/classifier.py
@@ -1,0 +1,178 @@
+"""
+Content-based routing for incoming memory packets.
+
+Each target file in `writer.DOMAIN_MAP` is treated as one document in a
+small corpus. On classification we tokenize the candidate packet body,
+compute a TF-IDF vector over the same vocabulary as the corpus, and
+route to the document with the highest cosine similarity. If the top
+score is below `CONFIDENCE_THRESHOLD` we fall back to `general` — the
+idea being that a separate "dreamer" agent will later re-sort anything
+that landed in general (or that landed in the wrong place).
+
+The corpus for each domain is the concatenation of:
+
+  1. A short seed blurb baked in below (gives cold-start behaviour when
+     the real file is empty or missing).
+  2. The live contents of the target file under `knowledge_root`, if it
+     exists.
+
+As real packets accumulate, (2) dominates and the seed's influence
+fades naturally.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from pathlib import Path
+
+from feed.writer import DOMAIN_MAP
+
+# Below this cosine score, classification is considered unreliable and
+# the packet falls back to `general`. Tuned against the prototype
+# dataset: real winners scored 0.07+ and pure noise stayed under 0.05.
+CONFIDENCE_THRESHOLD = 0.05
+
+# Seed descriptions — a short "topics covered" blurb per domain. These
+# give TF-IDF something to work with before any real content has
+# accumulated. Keep them lean: a dense list of distinctive vocabulary
+# beats prose.
+SEED_DESCRIPTIONS: dict[str, str] = {
+    "java": (
+        "Java JVM Spring Boot Spring Framework Maven Gradle Hibernate JPA "
+        "JUnit Mockito checked exceptions streams records sealed classes "
+        "virtual threads Kotlin interop."
+    ),
+    "python": (
+        "Python FastAPI Flask Django Pydantic dataclasses type hints "
+        "asyncio async await uv pip pytest ruff pandas numpy ASGI uvicorn "
+        "hypercorn coroutines."
+    ),
+    "golang": (
+        "Go golang goroutines channels context errgroup net http chi gin "
+        "table driven tests testing package go modules go vet golangci "
+        "lint gRPC protobuf."
+    ),
+    "api": (
+        "API design specs plans REST conventions resource modeling "
+        "pagination idempotency versioning OpenAPI JSON schema GraphQL "
+        "request validation error envelopes RFC design docs."
+    ),
+    "testing": (
+        "Testing unit integration contract end to end fixtures factories "
+        "golden files flaky triage property based hypothesis mocking "
+        "boundaries coverage."
+    ),
+    "observability": (
+        "Observability logs metrics traces OpenTelemetry Prometheus "
+        "Grafana dashboards structured logging correlation ids SLO SLI "
+        "error budgets distributed tracing alerting runbooks."
+    ),
+    "general": (
+        "Team process communication review etiquette onboarding "
+        "cross cutting notes."
+    ),
+}
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]+")
+
+# Minimal stopword list. Kept small on purpose — IDF does the real
+# filtering. Only the most frequent English function words are listed
+# here to keep vectors compact.
+_STOPWORDS = frozenset(
+    {
+        "the", "and", "for", "with", "that", "this", "from", "into", "over",
+        "a", "an", "of", "to", "in", "on", "is", "are", "be", "it", "as", "or",
+        "by", "at", "we", "you", "our", "but", "not", "if", "so", "do", "does",
+        "was", "were", "has", "have", "had", "will", "can", "should", "would",
+    }
+)
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase word tokens, stopwords removed, single-char tokens dropped."""
+    return [
+        t.lower()
+        for t in _TOKEN_RE.findall(text)
+        if t.lower() not in _STOPWORDS and len(t) > 1
+    ]
+
+
+def _compute_idf(docs: dict[str, list[str]]) -> dict[str, float]:
+    """Smoothed IDF: log((1 + N) / (1 + df)) + 1 (matches sklearn default)."""
+    n = len(docs)
+    df: Counter[str] = Counter()
+    for tokens in docs.values():
+        for term in set(tokens):
+            df[term] += 1
+    return {term: math.log((1 + n) / (1 + d)) + 1 for term, d in df.items()}
+
+
+def _tfidf_vector(tokens: list[str], idf: dict[str, float]) -> dict[str, float]:
+    """Raw-count TF times IDF, L2-normalized."""
+    tf = Counter(tokens)
+    vec = {term: count * idf.get(term, 0.0) for term, count in tf.items()}
+    norm = math.sqrt(sum(v * v for v in vec.values())) or 1.0
+    return {term: v / norm for term, v in vec.items()}
+
+
+def _cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    # Both vectors are already L2-normalized, so the dot product *is*
+    # the cosine similarity.
+    if len(a) > len(b):
+        a, b = b, a
+    return sum(v * b.get(term, 0.0) for term, v in a.items())
+
+
+def load_corpus(knowledge_root: str | Path) -> dict[str, str]:
+    """
+    Build the per-domain corpus by concatenating the seed blurb with the
+    live contents of each target file under `knowledge_root`. Missing
+    files are fine — the seed alone is enough to classify against.
+    """
+    root = Path(knowledge_root).expanduser()
+    corpus: dict[str, str] = {}
+    for domain, relative in DOMAIN_MAP.items():
+        seed = SEED_DESCRIPTIONS.get(domain, "")
+        target = root / relative
+        try:
+            live = target.read_text(encoding="utf-8") if target.exists() else ""
+        except OSError:
+            live = ""
+        corpus[domain] = f"{seed}\n{live}"
+    return corpus
+
+
+def score(body: str, corpus: dict[str, str]) -> list[tuple[str, float]]:
+    """Return [(domain, cosine_score), ...] sorted by descending score."""
+    doc_tokens = {name: tokenize(text) for name, text in corpus.items()}
+
+    # Fit IDF on corpus + query so that terms appearing only in the
+    # query still receive a meaningful weight.
+    fit_docs = dict(doc_tokens)
+    fit_docs["__query__"] = tokenize(body)
+    idf = _compute_idf(fit_docs)
+
+    doc_vectors = {name: _tfidf_vector(toks, idf) for name, toks in doc_tokens.items()}
+    query_vector = _tfidf_vector(tokenize(body), idf)
+
+    scored = [(name, _cosine(query_vector, vec)) for name, vec in doc_vectors.items()]
+    scored.sort(key=lambda p: p[1], reverse=True)
+    return scored
+
+
+def classify(body: str, corpus: dict[str, str]) -> str:
+    """
+    Route a packet body to a domain key. Returns `general` when the top
+    match falls below `CONFIDENCE_THRESHOLD` — the dreamer can re-sort
+    those later with richer context.
+    """
+    scored = score(body, corpus)
+    if not scored:
+        return "general"
+    winner, top_score = scored[0]
+    if top_score < CONFIDENCE_THRESHOLD:
+        return "general"
+    return winner

--- a/src/feed/main.py
+++ b/src/feed/main.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from feed.github import fetch_issues, add_label, RateLimitError
 from feed.governor import get_ruleset
 from feed.models import build_packets, Packet
-from feed.storage import load_state, save_state, advance_cursor, StoredPacket
+from feed.storage import load_state, save_state, advance_cursor, increment_stat, StoredPacket
 from feed.writer import incorporate, remove
 
 PORT = int(os.getenv("FEED_PORT", "2626"))
@@ -54,7 +54,7 @@ async def get_packets():
     global _packet_cache
     try:
         raw = await fetch_issues(GITHUB_REPO, _state.cursor, GITHUB_TOKEN)
-        packets = await build_packets(raw, GITHUB_ORG, GITHUB_TOKEN)
+        packets = await build_packets(raw, GITHUB_ORG, GITHUB_TOKEN, KNOWLEDGE_ROOT)
         # Exclude packets already in local incorporated/filtered lists
         local_ids = {p.id for p in _state.incorporated_packets} | {
             p.id for p in _state.filtered_packets
@@ -85,6 +85,7 @@ async def incorporate_packet(packet_id: int):
             packet.body,
         )
         _state.incorporated_packets.append(StoredPacket(**packet.model_dump()))
+        increment_stat(_state, "incorporated")
         advance_cursor(_state, packet.created_at)
         save_state(_state)
         return {"status": "incorporated", "file": str(file_path)}
@@ -99,6 +100,7 @@ async def filter_packet(packet_id: int):
         raise HTTPException(status_code=404, detail="Packet not found")
     try:
         _state.filtered_packets.append(StoredPacket(**packet.model_dump()))
+        increment_stat(_state, "filtered")
         advance_cursor(_state, packet.created_at)
         save_state(_state)
         return {"status": "filtered"}
@@ -114,6 +116,7 @@ async def quarantine_packet(packet_id: int):
     try:
         label = f"quarantined:{GITHUB_USER}"
         await add_label(GITHUB_REPO, packet.sequence_number, label, GITHUB_TOKEN)
+        increment_stat(_state, "quarantined")
         return {"status": "quarantined"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -178,8 +181,9 @@ async def get_filtered():
 @app.get("/api/stats")
 async def get_stats():
     return {
-        "incorporated": len(_state.incorporated_packets),
-        "filtered": len(_state.filtered_packets),
+        "incorporated": _state.session_stats.incorporated,
+        "filtered": _state.session_stats.filtered,
+        "quarantined": _state.session_stats.quarantined,
         "cursor": _state.cursor,
     }
 

--- a/src/feed/models.py
+++ b/src/feed/models.py
@@ -1,12 +1,11 @@
 """Shared Pydantic models and packet assembly."""
 
 import re
+from pathlib import Path
 from pydantic import BaseModel
 from feed.github import RawIssue, check_org_membership
-from feed.governor import classify
-from feed.writer import DOMAIN_MAP
-
-_KNOWN_DOMAINS = set(DOMAIN_MAP.keys())
+from feed.governor import classify as governor_classify
+from feed.classifier import classify as classify_domain, load_corpus
 
 
 class Packet(BaseModel):
@@ -34,15 +33,6 @@ def extract_team_brain(body: str) -> str:
     return after.strip()
 
 
-def extract_domain(labels: list) -> str:
-    """Return first matching known domain label, or 'general'."""
-    for label in labels:
-        name = label.name if hasattr(label, "name") else label.get("name", "")
-        if name in _KNOWN_DOMAINS and name != "general":
-            return name
-    return "general"
-
-
 def _extract_quarantined_by(labels: list) -> str | None:
     """If a 'quarantined:username' label exists, return the username."""
     for label in labels:
@@ -56,6 +46,7 @@ async def build_packets(
     raw_issues: list[RawIssue],
     org: str,
     token: str,
+    knowledge_root: str | Path,
 ) -> list[Packet]:
     """Fetch org membership per unique sender, classify each issue, return Packets."""
     membership_cache: dict[str, bool] = {}
@@ -65,9 +56,15 @@ async def build_packets(
         if login not in membership_cache:
             membership_cache[login] = await check_org_membership(org, login, token)
 
+    # Load the domain corpus once per batch — re-reading the knowledge
+    # base files for every packet would be wasteful.
+    corpus = load_corpus(knowledge_root)
+
     packets = []
     for issue in raw_issues:
-        # Skip issues already incorporated or filtered globally
+        # Skip issues already incorporated or filtered globally. These
+        # are *state* labels, not category labels — the feed still uses
+        # them for lifecycle tracking.
         label_names = {
             (l.name if hasattr(l, "name") else l.get("name", ""))
             for l in issue.labels
@@ -79,8 +76,8 @@ async def build_packets(
         is_member = membership_cache.get(login, False)
         raw_body = issue.body or ""
         body = extract_team_brain(raw_body) or raw_body
-        risk_level, threat_notes = classify(body, login, is_member)
-        domain = extract_domain(issue.labels)
+        risk_level, threat_notes = governor_classify(body, login, is_member)
+        domain = classify_domain(body, corpus)
         quarantined_by = _extract_quarantined_by(issue.labels)
 
         packets.append(

--- a/src/feed/storage.py
+++ b/src/feed/storage.py
@@ -20,6 +20,12 @@ class StoredPacket(BaseModel):
     threat_notes: list[str] = []
 
 
+class SessionStats(BaseModel):
+    incorporated: int = 0
+    filtered: int = 0
+    quarantined: int = 0
+
+
 class State(BaseModel):
     cursor: str = Field(
         default_factory=lambda: (
@@ -28,6 +34,8 @@ class State(BaseModel):
     )
     incorporated_packets: list[StoredPacket] = Field(default_factory=list)
     filtered_packets: list[StoredPacket] = Field(default_factory=list)
+    session_stats: SessionStats = Field(default_factory=SessionStats)
+    governor_rules: list = Field(default_factory=list)
 
 
 STATE_PATH = Path(os.getenv("FEED_STATE_PATH", Path.home() / ".feed" / "state.json"))
@@ -65,3 +73,8 @@ def advance_cursor(state: State, timestamp: str) -> None:
     """Update cursor only if timestamp is strictly newer."""
     if timestamp > state.cursor:
         state.cursor = timestamp
+
+
+def increment_stat(state: State, stat: str) -> None:
+    """Increment a session counter by name: 'incorporated', 'filtered', or 'quarantined'."""
+    setattr(state.session_stats, stat, getattr(state.session_stats, stat) + 1)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,106 @@
+"""Tests for TF-IDF content-based classification."""
+
+from feed.classifier import (
+    CONFIDENCE_THRESHOLD,
+    classify,
+    load_corpus,
+    score,
+    tokenize,
+)
+
+
+def test_tokenize_lowercases_and_drops_stopwords():
+    tokens = tokenize("The quick Brown fox and a lazy dog.")
+    assert "quick" in tokens
+    assert "brown" in tokens
+    assert "fox" in tokens
+    assert "the" not in tokens
+    assert "and" not in tokens
+
+
+def test_tokenize_drops_single_character_tokens():
+    assert "a" not in tokenize("a b c word")
+    assert "word" in tokenize("a b c word")
+
+
+def test_classify_routes_fastapi_to_python(tmp_path):
+    corpus = load_corpus(tmp_path)  # empty knowledge_root — seeds only
+    body = "When wiring up a FastAPI service, use Pydantic models and async def handlers."
+    assert classify(body, corpus) == "python"
+
+
+def test_classify_routes_semantic_python_without_literal_python_token(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Use async def with await for I/O-bound handlers; pytest-asyncio for coroutines."
+    assert classify(body, corpus) == "python"
+
+
+def test_classify_routes_spring_boot_to_java(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "In Spring Boot, prefer constructor injection so beans stay testable with JUnit and Mockito."
+    assert classify(body, corpus) == "java"
+
+
+def test_classify_routes_goroutines_to_golang(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Always pass context.Context first; use errgroup for fan-out goroutines."
+    assert classify(body, corpus) == "golang"
+
+
+def test_classify_routes_otel_to_observability(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Instrument with OpenTelemetry and attach correlation ids to structured logs."
+    assert classify(body, corpus) == "observability"
+
+
+def test_classify_routes_openapi_to_api(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Document REST endpoints in OpenAPI and return RFC 7807 problem details."
+    assert classify(body, corpus) == "api"
+
+
+def test_classify_ambiguous_falls_back_to_general(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Be kind. Ask questions."
+    assert classify(body, corpus) == "general"
+
+
+def test_classify_zero_overlap_falls_back_to_general(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Xylophone marmalade quibble."
+    assert classify(body, corpus) == "general"
+
+
+def test_score_returns_sorted_descending(tmp_path):
+    corpus = load_corpus(tmp_path)
+    scored = score("FastAPI Pydantic uvicorn", corpus)
+    scores = [s for _, s in scored]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_load_corpus_incorporates_live_file_content(tmp_path):
+    # Drop a file under the python target path and verify its content
+    # leaks into the python corpus entry.
+    python_path = tmp_path / "language-guidelines" / "python.md"
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("This file mentions a very unique token: zqxwce.")
+
+    corpus = load_corpus(tmp_path)
+    assert "zqxwce" in corpus["python"]
+
+
+def test_live_content_can_outweigh_seeds(tmp_path):
+    """A novel term sitting in a target file should pull matching packets to it."""
+    java_path = tmp_path / "language-guidelines" / "java.md"
+    java_path.parent.mkdir(parents=True)
+    # Stuff the java file with a distinctive made-up term.
+    java_path.write_text("flibbercrumble " * 20)
+
+    corpus = load_corpus(tmp_path)
+    assert classify("Notes on flibbercrumble and how to use it.", corpus) == "java"
+
+
+def test_confidence_threshold_is_reasonable():
+    # Sanity check: the threshold is a small positive number. If this
+    # ever changes dramatically it's worth re-tuning against real data.
+    assert 0.0 < CONFIDENCE_THRESHOLD < 0.2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
-"""Tests for packet assembly and domain extraction."""
+"""Tests for packet assembly and content-based domain classification."""
 
 import pytest
 from unittest.mock import AsyncMock, patch
-from feed.models import extract_domain, build_packets, Packet
+from feed.models import build_packets, Packet
 from feed.github import RawIssue, IssueLabel, IssueUser
 
 
@@ -10,48 +10,28 @@ def make_labels(*names):
     return [IssueLabel(name=n) for n in names]
 
 
-def make_issue(number=1, labels=None, login="alice"):
+def make_issue(number=1, labels=None, login="alice", body="Some content."):
     return RawIssue(
         id=number,
         number=number,
         title="Test issue",
-        body="Some content.",
+        body=body,
         user=IssueUser(login=login, avatar_url="https://example.com/avatar.png"),
         labels=labels or [],
         created_at="2026-04-03T08:00:00Z",
     )
 
 
-def test_domain_java():
-    labels = make_labels("memory", "java")
-    assert extract_domain(labels) == "java"
-
-
-def test_domain_no_known_label_returns_general():
-    labels = make_labels("memory", "unknown-tag")
-    assert extract_domain(labels) == "general"
-
-
-def test_domain_empty_labels_returns_general():
-    assert extract_domain([]) == "general"
-
-
-def test_domain_multiple_labels_picks_first_known():
-    labels = make_labels("memory", "python", "java")
-    assert extract_domain(labels) == "python"
-
-
-def test_domain_general_label_returns_general():
-    labels = make_labels("memory", "general")
-    assert extract_domain(labels) == "general"
-
-
 @pytest.mark.asyncio
-async def test_build_packets_returns_packet_list():
-    issue = make_issue(number=41, labels=make_labels("memory", "java"))
+async def test_build_packets_classifies_java_from_body(tmp_path):
+    issue = make_issue(
+        number=41,
+        labels=make_labels("memory"),
+        body="In Spring Boot, prefer constructor injection so beans stay testable with JUnit and Mockito.",
+    )
 
     with patch("feed.models.check_org_membership", new=AsyncMock(return_value=True)):
-        packets = await build_packets([issue], "myorg", "token")
+        packets = await build_packets([issue], "myorg", "token", tmp_path)
 
     assert len(packets) == 1
     p = packets[0]
@@ -63,26 +43,89 @@ async def test_build_packets_returns_packet_list():
 
 
 @pytest.mark.asyncio
-async def test_build_packets_caches_membership_lookup():
+async def test_build_packets_classifies_python_from_body(tmp_path):
+    issue = make_issue(
+        number=42,
+        labels=make_labels("memory"),
+        body="FastAPI handlers should be async def; use Pydantic for request validation and uvicorn to serve.",
+    )
+
+    with patch("feed.models.check_org_membership", new=AsyncMock(return_value=True)):
+        packets = await build_packets([issue], "myorg", "token", tmp_path)
+
+    assert packets[0].domain == "python"
+
+
+@pytest.mark.asyncio
+async def test_build_packets_ignores_category_labels(tmp_path):
+    """Category labels like 'java' must no longer influence routing."""
+    issue = make_issue(
+        number=43,
+        # Label says java, body screams python — body should win.
+        labels=make_labels("memory", "java"),
+        body="Use pytest fixtures with async def and asyncio; avoid mocking internal helpers.",
+    )
+
+    with patch("feed.models.check_org_membership", new=AsyncMock(return_value=True)):
+        packets = await build_packets([issue], "myorg", "token", tmp_path)
+
+    assert packets[0].domain != "java"
+
+
+@pytest.mark.asyncio
+async def test_build_packets_ambiguous_body_falls_back_to_general(tmp_path):
+    issue = make_issue(
+        number=44,
+        labels=make_labels("memory"),
+        body="Be kind in reviews. Ask questions before proposing rewrites.",
+    )
+
+    with patch("feed.models.check_org_membership", new=AsyncMock(return_value=True)):
+        packets = await build_packets([issue], "myorg", "token", tmp_path)
+
+    assert packets[0].domain == "general"
+
+
+@pytest.mark.asyncio
+async def test_build_packets_caches_membership_lookup(tmp_path):
     issues = [
-        make_issue(number=1, labels=make_labels("java")),
-        make_issue(number=2, labels=make_labels("python")),
+        make_issue(number=1, body="Goroutines and channels."),
+        make_issue(number=2, body="Pytest fixtures and asyncio."),
     ]
     mock_check = AsyncMock(return_value=True)
 
     with patch("feed.models.check_org_membership", new=mock_check):
-        await build_packets(issues, "myorg", "token")
+        await build_packets(issues, "myorg", "token", tmp_path)
 
-    # Same sender "alice" — membership should only be checked once
+    # Same sender "alice" — membership should only be checked once.
     assert mock_check.call_count == 1
 
 
 @pytest.mark.asyncio
-async def test_build_packets_non_member_gets_threat():
-    issue = make_issue(number=99, labels=make_labels("java"), login="outsider")
+async def test_build_packets_non_member_gets_threat(tmp_path):
+    issue = make_issue(
+        number=99,
+        login="outsider",
+        body="Use virtual threads in Spring Boot.",
+    )
 
     with patch("feed.models.check_org_membership", new=AsyncMock(return_value=False)):
-        packets = await build_packets([issue], "myorg", "token")
+        packets = await build_packets([issue], "myorg", "token", tmp_path)
 
     assert packets[0].risk_level == "threat"
     assert "non-org sender" in packets[0].threat_notes
+
+
+@pytest.mark.asyncio
+async def test_build_packets_skips_incorporated_state_label(tmp_path):
+    """`incorporated` is a state label, not a category — still must suppress the packet."""
+    issue = make_issue(
+        number=50,
+        labels=make_labels("memory", "incorporated"),
+        body="Use virtual threads.",
+    )
+
+    with patch("feed.models.check_org_membership", new=AsyncMock(return_value=True)):
+        packets = await build_packets([issue], "myorg", "token", tmp_path)
+
+    assert packets == []

--- a/tfidf_prototype.py
+++ b/tfidf_prototype.py
@@ -1,0 +1,193 @@
+"""
+TF-IDF routing prototype for the memory feed.
+
+Self-contained — no external deps. Seeds each DOMAIN_MAP target file with
+a short, realistic "topics covered" blurb (what the 'dreamer' would leave
+behind over time), then scores several candidate memories against the
+corpus and prints the winning route plus the full score table.
+
+Run:  python tfidf_prototype.py
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+
+# Mirror of feed.writer.DOMAIN_MAP, but with seed content inline so the
+# prototype runs against realistic text instead of empty files.
+SEED_CORPUS: dict[str, str] = {
+    "java": """
+        Java and the JVM. Spring Boot, Spring Framework, Maven, Gradle.
+        Hibernate and JPA for persistence. JUnit and Mockito for tests.
+        Checked exceptions, streams, records, sealed classes, virtual threads.
+        Kotlin interop notes live here too.
+    """,
+    "python": """
+        Python 3 idioms. FastAPI, Flask, Django for web. Pydantic models,
+        dataclasses, type hints, asyncio and async/await. uv and pip for
+        packaging, pytest for tests, ruff for linting. Pandas and numpy
+        for data work. ASGI servers like uvicorn and hypercorn.
+    """,
+    "golang": """
+        Go and goroutines. Channels, context, errgroup. Standard library
+        net/http, chi and gin routers. Table-driven tests with the testing
+        package. Go modules, go vet, golangci-lint. gRPC with protobuf.
+    """,
+    "api": """
+        API design, specs, and plans. REST conventions, resource modeling,
+        pagination, idempotency keys, versioning. OpenAPI and JSON schema.
+        GraphQL schema design. Request validation and error envelopes.
+        Writing RFCs and design docs before implementation.
+    """,
+    "testing": """
+        Testing philosophy and practice. Unit tests, integration tests,
+        contract tests, end-to-end tests. Fixtures, factories, golden files.
+        Flaky test triage. Property-based testing with hypothesis. Mocking
+        boundaries, not internals. Coverage as a smell, not a goal.
+    """,
+    "observability": """
+        Observability: logs, metrics, traces. OpenTelemetry instrumentation,
+        Prometheus metrics, Grafana dashboards. Structured logging with
+        correlation ids. SLOs, SLIs, error budgets. Distributed tracing
+        across service boundaries. Alerting hygiene and runbooks.
+    """,
+    "general": """
+        Catch-all for cross-cutting notes that do not fit a specific
+        language or topic. Team process, communication norms, review
+        etiquette, onboarding notes.
+    """,
+}
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]+")
+
+# Minimal stopword list — just the worst offenders. Kept small on purpose
+# so you can see the effect of IDF doing the real filtering.
+_STOPWORDS = {
+    "the", "and", "for", "with", "that", "this", "from", "into", "over",
+    "a", "an", "of", "to", "in", "on", "is", "are", "be", "it", "as", "or",
+    "by", "at", "we", "you", "our", "but", "not", "if", "so", "do", "does",
+}
+
+
+def tokenize(text: str) -> list[str]:
+    return [
+        t.lower()
+        for t in _TOKEN_RE.findall(text)
+        if t.lower() not in _STOPWORDS and len(t) > 1
+    ]
+
+
+def compute_idf(docs: dict[str, list[str]]) -> dict[str, float]:
+    """Smoothed IDF, matching sklearn's default formula: log((1+N)/(1+df)) + 1."""
+    n = len(docs)
+    df: Counter[str] = Counter()
+    for tokens in docs.values():
+        for term in set(tokens):
+            df[term] += 1
+    return {term: math.log((1 + n) / (1 + d)) + 1 for term, d in df.items()}
+
+
+def tfidf_vector(tokens: list[str], idf: dict[str, float]) -> dict[str, float]:
+    tf = Counter(tokens)
+    vec = {term: count * idf.get(term, 0.0) for term, count in tf.items()}
+    # L2 normalize
+    norm = math.sqrt(sum(v * v for v in vec.values())) or 1.0
+    return {term: v / norm for term, v in vec.items()}
+
+
+def cosine(a: dict[str, float], b: dict[str, float]) -> float:
+    # Both already L2-normalized, so dot product == cosine similarity.
+    if len(a) > len(b):
+        a, b = b, a
+    return sum(v * b.get(term, 0.0) for term, v in a.items())
+
+
+def route(query: str, corpus: dict[str, str]) -> list[tuple[str, float]]:
+    """Return [(domain, score), ...] sorted by descending score."""
+    doc_tokens = {name: tokenize(text) for name, text in corpus.items()}
+
+    # Fit IDF on corpus + query so query-only terms still get weight.
+    # (We give the query a synthetic doc name so it contributes to df.)
+    fit_docs = dict(doc_tokens)
+    fit_docs["__query__"] = tokenize(query)
+    idf = compute_idf(fit_docs)
+
+    doc_vecs = {name: tfidf_vector(toks, idf) for name, toks in doc_tokens.items()}
+    query_vec = tfidf_vector(tokenize(query), idf)
+
+    scored = [(name, cosine(query_vec, vec)) for name, vec in doc_vecs.items()]
+    scored.sort(key=lambda p: p[1], reverse=True)
+    return scored
+
+
+def print_report(label: str, query: str, corpus: dict[str, str]) -> None:
+    scored = route(query, corpus)
+    winner, top_score = scored[0]
+    runner_up_score = scored[1][1] if len(scored) > 1 else 0.0
+    margin = top_score - runner_up_score
+
+    print(f"\n=== {label} ===")
+    print(f"Query: {query.strip()[:120]}{'...' if len(query.strip()) > 120 else ''}")
+    print(f"Winner: {winner}  (score={top_score:.4f}, margin over #2={margin:.4f})")
+    print("All scores:")
+    for name, score in scored:
+        bar = "#" * int(score * 40)
+        print(f"  {name:<14} {score:.4f}  {bar}")
+
+
+QUERIES: list[tuple[str, str]] = [
+    (
+        "The canonical FastAPI case",
+        "When wiring up a FastAPI service, prefer Pydantic v2 models for "
+        "request validation and use async def handlers so uvicorn can "
+        "multiplex connections.",
+    ),
+    (
+        "Semantic-only Python (no literal 'python' token)",
+        "Use async def with await for I/O-bound handlers; pytest-asyncio "
+        "lets you test coroutines without a custom event loop fixture.",
+    ),
+    (
+        "Spring Boot note — should land in java",
+        "In Spring Boot, prefer constructor injection over field injection "
+        "so beans stay testable with plain JUnit and Mockito.",
+    ),
+    (
+        "Go concurrency note",
+        "Always pass context.Context as the first argument to functions "
+        "that may block on I/O; use errgroup for fan-out goroutines.",
+    ),
+    (
+        "Testing philosophy note",
+        "Mock at module boundaries, not internal helpers. Prefer fixtures "
+        "over setUp/tearDown. Treat flaky tests as bugs, not noise.",
+    ),
+    (
+        "Observability note",
+        "Instrument with OpenTelemetry and export traces to the collector; "
+        "attach correlation ids to structured logs for cross-service joins.",
+    ),
+    (
+        "API design note",
+        "Version REST endpoints in the URL, return RFC 7807 problem "
+        "details for errors, and document everything in OpenAPI.",
+    ),
+    (
+        "Ambiguous / should fall back to general",
+        "Be kind in code reviews. Ask questions before proposing rewrites.",
+    ),
+    (
+        "Novel term with zero corpus overlap",
+        "Prefer Bazel remote cache with BuildBuddy for hermetic builds.",
+    ),
+]
+
+
+if __name__ == "__main__":
+    print("TF-IDF routing prototype")
+    print(f"Corpus: {len(SEED_CORPUS)} documents")
+    for label, query in QUERIES:
+        print_report(label, query, SEED_CORPUS)


### PR DESCRIPTION
## Summary

- **No more category labels.** Domain routing (`java`, `python`, `testing`, etc.) no longer depends on GitHub issue labels. The only label the ingest path cares about is `memory`.
- **TF-IDF classifier** (`src/feed/classifier.py`) routes each packet by cosine similarity against the live knowledge base files. Baked-in seed vocabulary handles cold start; live file content dominates as the knowledge base grows. Packets below the confidence threshold fall back to `CLAUDE.md` for the dreamer to re-sort later.
- **Restored broken tests.** `SessionStats`, `increment_stat`, and `governor_rules` were missing from `storage.py`; all three test files that depended on them were failing. Restored the model and helper, wired stat tracking into the three mutating endpoints, and fixed `/api/stats` to include `quarantined`.
- **`make test`** added via a new `Makefile` — runs `uv run pytest` across the full suite (72 tests, all passing).
- **README** updated with a "How routing works" section, a "The dreamer" section describing the expected background agent, and revised GitHub setup instructions.

## Test plan

- [ ] `make test` — all 72 tests pass
- [ ] Start the daemon, open an issue with only the `memory` label and Java content (e.g. "Prefer constructor injection in Spring Boot"); verify it routes to `language-guidelines/java.md` on incorporate
- [ ] Try an ambiguous issue ("be kind in reviews") — should route to `CLAUDE.md`
- [ ] Confirm category labels like `java` on an issue with Python body content are ignored by the router

🤖 Generated with [Claude Code](https://claude.com/claude-code)