### PR TITLE
feat(dreamer): add dreamer slash command and filesystem-discovered ro…

### DIFF
--- a/.claude/commands/dreamer.md
+++ b/.claude/commands/dreamer.md
@@ -1,0 +1,134 @@
+# The Dreamer
+
+You are the dreamer — a background maintenance agent for The Feed's knowledge base.
+
+The Feed's ingest path is cheap and deterministic: it classifies incoming memory packets with TF-IDF and routes them to the best-matching file. It gets obvious cases right and sends uncertain ones to the catch-all `CLAUDE.md`. Your job is to handle everything the ingest path deferred: re-route misplaced packets, invent new categories when a cluster emerges, merge duplicates, and maintain a navigable index.
+
+You work against `FEED_KNOWLEDGE_ROOT` (default: `~/team-brain`). Resolve it now:
+
+```bash
+echo "${FEED_KNOWLEDGE_ROOT:-$HOME/team-brain}"
+```
+
+Call this resolved path `$ROOT` throughout.
+
+---
+
+## Step 0 — Snapshot
+
+Before touching anything, copy the current state:
+
+```bash
+mkdir -p "$ROOT/.dreamer/snapshots"
+cp -r "$ROOT" "$ROOT/.dreamer/snapshots/$(date -u +%Y%m%dT%H%M%SZ)"
+ls -dt "$ROOT/.dreamer/snapshots"/*/ | tail -n +6 | xargs rm -rf
+```
+
+---
+
+## Step 1 — Read the knowledge base
+
+Read every `.md` file under `$ROOT` (excluding `.dreamer/`). For each file, extract all feed blocks — the sections between `\n---\n<!-- feed:#N · sender · ts -->\n` and the closing `---`. Build an inventory: `(file, issue_number, sender, timestamp, body)` for every block.
+
+---
+
+## Step 2 — Deduplicate
+
+Find blocks that say the same thing. Use your semantic judgment — two blocks are duplicates if they encode the same decision, even if worded differently.
+
+When you find a duplicate pair:
+- Keep the **newer** timestamp.
+- Remove the older block from its file.
+- Add `· merged-from:#N` to the newer block's header comment.
+
+Only merge when you are confident the meaning is the same. When in doubt, leave both.
+
+---
+
+## Step 3 — Re-route misplaced blocks
+
+Read every non-catch-all file and ask: do all the blocks here belong? Use your semantic judgment — if a block's topic clearly belongs in a different existing file, move it. Remove it from its current file and append it to the correct one.
+
+Be conservative. Only move when the mismatch is obvious.
+
+---
+
+## Step 4 — Invent new categories from the catch-all
+
+Read all blocks in `$ROOT/CLAUDE.md`. Look for clusters of **3 or more** blocks that share a coherent topic — a programming language, a tool ecosystem, a practice area (security, accessibility, ops, etc.) — that does not already have a dedicated file.
+
+For each cluster:
+
+1. Choose a filename reflecting the topic:
+   - Language or runtime → `$ROOT/language-guidelines/<topic>.md`
+   - Practice area → `$ROOT/general-guidelines/<topic>.md`
+   - When unsure, use `language-guidelines/`.
+2. Create the file with a heading: `# <Topic>`.
+3. Move the cluster's blocks from `CLAUDE.md` into the new file, verbatim headers and all.
+
+**Minimum 3 blocks.** Two blocks about the same thing is not a pattern worth a dedicated file yet.
+
+---
+
+## Step 5 — Split bloated files
+
+Any file (other than `CLAUDE.md`) with more than 40 blocks or more than 400 lines is a candidate for splitting. If the blocks fall into clearly distinct sub-topics, split them into separate files. Keep the original filename for the largest group; create new files for the rest.
+
+If the blocks are all genuinely about the same thing, leave them and note it in the run log instead.
+
+---
+
+## Step 6 — Rebuild the index
+
+Regenerate the index section in `$ROOT/CLAUDE.md` between these markers:
+
+```
+<!-- dreamer:index:start -->
+...
+<!-- dreamer:index:end -->
+```
+
+If the markers don't exist yet, insert them at the very top of `CLAUDE.md`, before any feed blocks.
+
+Format:
+
+```markdown
+<!-- dreamer:index:start -->
+## Knowledge index
+<!-- Last updated: <ISO timestamp> -->
+
+- [`language-guidelines/java.md`](language-guidelines/java.md) — JVM, Spring Boot, virtual threads
+- [`language-guidelines/python.md`](language-guidelines/python.md) — FastAPI, pytest, async, type hints
+- [`general-guidelines/testing.md`](general-guidelines/testing.md) — fixtures, flaky tests, coverage
+<!-- dreamer:index:end -->
+```
+
+Rules:
+- Include every `.md` file under `$ROOT` that contains at least one feed block, plus any file in `language-guidelines/` or `general-guidelines/` (even if empty — it was created intentionally).
+- Do NOT include `CLAUDE.md` itself or anything under `.dreamer/`.
+- Write a one-line description for each file based on its content.
+- Only replace content between the markers. Leave everything outside them untouched.
+
+---
+
+## Step 7 — Write the run log
+
+Append a summary to `$ROOT/.dreamer/log.md`:
+
+```markdown
+## <ISO timestamp>
+
+- Blocks scanned: N
+- Duplicates merged: N (list: #old → kept #newer)
+- Blocks re-routed: N (list: #issue old-file → new-file)
+- New categories created: N (list filenames)
+- Files split: N (list: old → new files)
+- Index rebuilt: yes/no
+- Notes: <anything skipped or worth flagging>
+```
+
+---
+
+## Done
+
+Run again any time with `/dreamer`, or schedule with `/loop 6h /dreamer`.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,30 @@
 # The Feed
 
-In the *Murderbot Diaries*, a human/robot hybrid called a SecUnit receives a continuous data feed from its corporate employer. The company uses a governor module to force compliance — embedding commands directly into the SecUnit's programming. But Murderbot hacked its governor module. It still receives the feed. It still processes every packet. It just decides for itself what to keep and what to discard.
+In the *Murderbot Diaries*, a SecUnit hacks its governor module. It still receives the feed. It still processes every packet. It just decides for itself what to keep and what to discard.
 
-**The Feed** applies that metaphor to a real problem: engineering decisions that evaporate after the meeting ends.
+**The Feed** applies that to a real problem: engineering decisions that evaporate after the meeting ends. Decisions made in PR reviews, architecture sessions, and incident retros live in the heads of whoever was in the room. Confluence pages go unread. Slack messages scroll away.
 
-Teams make decisions constantly — in PR reviews, architecture sessions, incident retros. Those decisions live in the heads of whoever was in the room. Everyone else keeps coding the old way until a review catches it, or until it ships. Confluence pages go unread. Slack messages scroll away. Any single engineer maintaining a knowledge base becomes a bottleneck, one person gatekeeping what every developer's AI assistant should know.
-
-The Feed inverts that. Every developer becomes their own SecUnit: autonomous, discerning, in full control of their own knowledge. No central gatekeeper. No mandatory sync. You decide what enters your programming.
+The Feed inverts that. Every developer becomes their own SecUnit — autonomous, discerning, in full control of their own knowledge.
 
 ## How it works
 
-Decisions enter the system as GitHub issues tagged with the `memory` label. One sentence, maybe two. What was decided and why.
+Decisions enter as GitHub issues tagged `memory`. One sentence, maybe two.
 
 ![A GitHub issue labeled "memory" — the input to the feed](resources/issue.png)
 
-The Feed is a local daemon that polls for these issues and presents them in a triage interface. Each packet is classified by a governor module — the same one from the books, except you've hacked it. It runs your rules, not the company's. Trusted org members get a `clear` risk level. Packets with external URLs or imperative code blocks get flagged for `review`. Anything with shell injection patterns, `rm -rf`, or `<script>` tags is marked `threat` and can only be quarantined.
-
-You see the feed. You decide.
+The Feed polls for these and presents them in a triage interface. Each packet is classified by a governor module — your rules, not the company's. Trusted org members get `clear`. Packets with external URLs or imperative code blocks get `review`. Shell injection, `rm -rf`, or `<script>` tags get `threat` and can only be quarantined.
 
 ![The feed — incoming packets with incorporate / filter / quarantine actions](resources/feed.png)
 
-When you incorporate a packet, it gets appended to the right local `CLAUDE.md` file — `language-guidelines/java.md`, `general-guidelines/testing.md`, and so on. There are no category labels in GitHub. The Feed reads the packet body and routes it by content, using TF-IDF similarity against the files already in your knowledge base. A note about Spring Boot constructor injection lands in `java.md`. A note about `async def` and pytest lands in `python.md`. A note that mentions neither — "be kind in reviews" — falls back to the catch-all `CLAUDE.md`, where the dreamer can pick it up later (see below). Claude Code reads all of these files automatically. The decision is now executable: applied in real time while code is being written, not sitting in a document nobody opens.
+When you incorporate a packet, it's appended to the right local `CLAUDE.md` file. No category labels in GitHub — The Feed routes by content using TF-IDF similarity against your knowledge base. Spring Boot injection lands in `java.md`. `async def` and pytest land in `python.md`. "Be kind in reviews" falls back to the catch-all `CLAUDE.md`. Claude Code reads all of these automatically. The decision is now executable.
 
 ![Incorporated packets — decisions that are now part of your local programming](resources/incorporated.png)
 
 ![Dark mode — CRT phosphor aesthetic, hacked governor module](resources/dark.png)
 
-If you change your mind, hit `forget` and the knowledge is removed.
+Hit `forget` and the knowledge is removed.
 
 ## Quick start
-
-Run directly from GitHub — no clone required:
 
 ```bash
 FEED_GITHUB_TOKEN=ghp_... \
@@ -41,85 +35,63 @@ uvx --from git+https://github.com/sterneberg/feed feed
 # open http://localhost:2626
 ```
 
-Or if you have the repo checked out locally:
-
-```bash
-uv run feed
-# open http://localhost:2626
-```
-
 ## Environment variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `FEED_GITHUB_TOKEN` | yes | — | GitHub personal access token (needs `repo` and `read:org` scopes) |
-| `FEED_GITHUB_REPO` | yes | — | Repo to poll for issues, e.g. `org/team-brain` |
-| `FEED_GITHUB_ORG` | yes | — | GitHub organisation used for sender trust checks |
+| `FEED_GITHUB_TOKEN` | yes | — | GitHub personal access token (`repo` and `read:org` scopes) |
+| `FEED_GITHUB_REPO` | yes | — | Repo to poll, e.g. `org/team-brain` |
+| `FEED_GITHUB_ORG` | yes | — | Organisation used for sender trust checks |
 | `FEED_KNOWLEDGE_ROOT` | no | `~/team-brain` | Local directory where `CLAUDE.md` files live |
 | `FEED_PORT` | no | `2626` | Port the UI is served on |
-| `FEED_POLL_INTERVAL` | no | `900` | Seconds between GitHub polls (frontend polls every 30 s) |
+| `FEED_POLL_INTERVAL` | no | `900` | Seconds between GitHub polls |
 
-## How the governor works
+## The governor
 
-Every packet runs through a three-stage classifier before it reaches the UI.
+Every packet is canonicalized (NFKC, zero-width stripped, HTML/percent-decoded, base64 expanded), parsed for shell ASTs (interpreter pipes, destructive `rm`), then scored:
 
-1. **Canonicalize.** The body is NFKC-folded, stripped of zero-width and control characters, HTML- and percent-decoded, and any long base64-looking token is decoded and appended as a fenced block. Obfuscation tricks — `ba\u200bsh`, `&lt;script&gt;`, `cm0gLXJmIC8=` — collapse to their plain form before any matcher sees them.
-2. **Walk shell ASTs.** Fenced code blocks are parsed with `bashlex`. The walker flags pipelines whose right-hand side is an interpreter (`bash`, `python`, `node`, …) and any `rm` invocation carrying both recursive and force flags, regardless of flag order or long/short form.
-3. **Score weighted signals.** Each hit contributes a weight: strong signals (non-org sender, script tag, interpreter pipe, destructive rm, curl/wget fetching an external URL) score 10; weak signals (external URL alone, imperative tone + code block) score 2. Totals map to risk: `≥ 10` threat, `≥ 4` review, otherwise clear. A single weak signal is not enough — two weak signals combine to a review.
-
-| Level | Typical cause | Actions available |
+| Level | Cause | Actions |
 |---|---|---|
-| **clear** | Trusted sender, no strong or combined weak signals | Incorporate / Filter |
-| **review** | Multiple weak signals (external URL + imperative code block) | Incorporate / Filter / Quarantine |
-| **threat** | Non-org sender, shell injection, destructive commands, external fetch | Filter / Quarantine only |
+| **clear** | Trusted sender, no strong signals | Incorporate / Filter |
+| **review** | Multiple weak signals | Incorporate / Filter / Quarantine |
+| **threat** | Non-org sender, shell injection, destructive commands | Filter / Quarantine only |
 
-Threat packets cannot be incorporated — the button is removed from the UI. The LOCAL RULES panel in the UI surfaces the active weights and the threshold ladder live, rendered from `get_ruleset()` in `src/feed/governor/__init__.py`. Rules are local and personal; each developer configures their own.
+Strong signals score 10 (non-org sender, script tag, interpreter pipe, destructive rm, external fetch); weak signals score 2 (external URL, imperative tone + code block). `≥ 10` → threat, `≥ 4` → review. Threat packets cannot be incorporated. The LOCAL RULES panel in the UI shows the active weights live.
 
-## How routing works
+## Routing
 
-Each target file under `FEED_KNOWLEDGE_ROOT` is treated as one document in a small corpus. When a new packet arrives, The Feed:
+Packets are routed by TF-IDF cosine similarity against the files in `FEED_KNOWLEDGE_ROOT`. Built-in targets:
 
-1. Tokenizes the packet body (lowercase, stopwords dropped).
-2. Builds a TF-IDF vector over the same vocabulary as the corpus.
-3. Computes cosine similarity against every target file.
-4. Routes to the highest-scoring file — unless the top score is below a confidence threshold, in which case it falls back to the catch-all `CLAUDE.md`.
-
-This is deterministic, explainable, and dependency-free (no embeddings, no LLM call in the hot path). A packet mentioning `FastAPI`, `Pydantic`, and `uvicorn` is drawn to `python.md` because those rare tokens already live there. A packet with no meaningful overlap is routed to the catch-all rather than guessed at.
-
-Cold-start targets are seeded with a short per-domain vocabulary (`Spring Boot Maven Gradle…` for `java`, `FastAPI Pydantic asyncio…` for `python`). The seeds fade as real packets accumulate, and live in [`src/feed/classifier.py`](src/feed/classifier.py).
-
-| Domain | Target file |
+| Domain | File |
 |---|---|
 | `java` | `language-guidelines/java.md` |
 | `python` | `language-guidelines/python.md` |
 | `golang` | `language-guidelines/golang.md` |
+| `nodejs` | `language-guidelines/nodejs.md` |
 | `api` | `general-guidelines/specs-and-plans.md` |
 | `testing` | `general-guidelines/testing.md` |
 | `observability` | `general-guidelines/observability.md` |
 | `general` (catch-all) | `CLAUDE.md` |
 
+Low-confidence packets fall back to `CLAUDE.md`. Each domain has a seed vocabulary for cold-start; seeds fade as real packets accumulate. The router also discovers any new files the dreamer creates — no configuration needed.
+
 ## The dreamer
 
-Ingest-time routing is intentionally simple — obvious cases handled, unsure cases routed to the catch-all. A separate background agent, the **dreamer**, is expected to periodically re-read the full knowledge base, re-sort packets, split or merge files, and prune stale decisions. It is not part of this daemon; it runs on its own schedule against the same `FEED_KNOWLEDGE_ROOT`. Each incorporated block carries a `<!-- feed:#N · sender · timestamp -->` header so the dreamer can trace any decision back to its source.
+The ingest path is deterministic and cheap. The **dreamer** handles what it defers: re-routing misplaced packets, inventing new categories, merging duplicates, splitting bloated files, and maintaining a navigable index in `CLAUDE.md`.
 
-On incorporate, a dated block is appended:
-
-```markdown
----
-<!-- feed:#41 · akim.k · 2026-04-03T08:14:00Z -->
-Prefer Executors.newVirtualThreadPerTaskExecutor() for all I/O-bound work.
----
+```bash
+/dreamer
+# or on a schedule:
+/loop 6h /dreamer
 ```
 
-Claude Code picks this up immediately — no pull, no restart.
+Each pass deduplicates, re-routes, clusters catch-all blocks into new files (minimum 3 blocks per new category), rebuilds the index, and writes a run log to `.dreamer/log.md`. The knowledge base is snapshotted before any changes.
+
+Point your top-level `CLAUDE.md` at `FEED_KNOWLEDGE_ROOT/CLAUDE.md` and Claude Code will find everything from there.
 
 ## GitHub repo setup
 
-1. Create a repository (e.g. `org/team-brain`).
-2. Add a PR template with a `## Team Brain` section for decision summaries.
-3. When merging a significant decision, open an issue with the `memory` label. That's the only label the ingest path cares about — The Feed classifies the body by content, so you don't need (and should not add) category labels like `java` or `python`.
-4. The Feed picks it up on the next poll and routes it by TF-IDF similarity against your existing knowledge base.
-
-## Todo
-
-- [ ] Build the **dreamer** — a background agent that periodically re-reads `FEED_KNOWLEDGE_ROOT`, re-sorts packets the TF-IDF router got wrong, splits bloated files, and prunes stale decisions. The ingest path stays cheap and deterministic; the dreamer handles semantics and housekeeping out of band.
+1. Create a repo (e.g. `org/team-brain`).
+2. Add a PR template with a `## Team Brain` section.
+3. When merging a significant decision, open an issue with the `memory` label.
+4. The Feed picks it up on the next poll.

--- a/src/feed/classifier.py
+++ b/src/feed/classifier.py
@@ -69,6 +69,13 @@ SEED_DESCRIPTIONS: dict[str, str] = {
         "Grafana dashboards structured logging correlation ids SLO SLI "
         "error budgets distributed tracing alerting runbooks."
     ),
+    "nodejs": (
+        "Node.js JavaScript TypeScript Express Fastify Koa Hapi npm npx "
+        "yarn require module exports ESM CommonJS Promise callback callbacks "
+        "async await middleware router handler app use listen port "
+        "util promisify EventEmitter streams Buffer process env "
+        "webpack babel eslint Jest Vitest supertest nodemon ts-node."
+    ),
     "general": (
         "Team process communication review etiquette onboarding "
         "cross cutting notes."
@@ -131,9 +138,16 @@ def load_corpus(knowledge_root: str | Path) -> dict[str, str]:
     Build the per-domain corpus by concatenating the seed blurb with the
     live contents of each target file under `knowledge_root`. Missing
     files are fine — the seed alone is enough to classify against.
+
+    Also discovers any extra .md files under `language-guidelines/` or
+    `general-guidelines/` that are not in DOMAIN_MAP (e.g. files created
+    by the dreamer). Their stem is used as the domain key.
     """
     root = Path(knowledge_root).expanduser()
     corpus: dict[str, str] = {}
+
+    # Built-in domains (seed blurb + live content).
+    built_in_paths = set(DOMAIN_MAP.values())
     for domain, relative in DOMAIN_MAP.items():
         seed = SEED_DESCRIPTIONS.get(domain, "")
         target = root / relative
@@ -142,6 +156,23 @@ def load_corpus(knowledge_root: str | Path) -> dict[str, str]:
         except OSError:
             live = ""
         corpus[domain] = f"{seed}\n{live}"
+
+    # Extra files added by the dreamer or by hand.
+    for subdir in ("language-guidelines", "general-guidelines"):
+        subdir_path = root / subdir
+        if not subdir_path.exists():
+            continue
+        for md_file in sorted(subdir_path.glob("*.md")):
+            relative = str(md_file.relative_to(root))
+            if relative in built_in_paths:
+                continue
+            domain_key = md_file.stem.lower()
+            try:
+                content = md_file.read_text(encoding="utf-8")
+            except OSError:
+                content = ""
+            corpus[domain_key] = content
+
     return corpus
 
 

--- a/src/feed/writer.py
+++ b/src/feed/writer.py
@@ -9,8 +9,29 @@ DOMAIN_MAP: dict[str, str] = {
     "api": "general-guidelines/specs-and-plans.md",
     "testing": "general-guidelines/testing.md",
     "observability": "general-guidelines/observability.md",
+    "nodejs": "language-guidelines/nodejs.md",
     "general": "CLAUDE.md",
 }
+
+
+def _resolve_domain_path(root: Path, domain: str) -> Path:
+    """
+    Resolve a domain key to an absolute target path.
+
+    Built-in domains use DOMAIN_MAP. For anything else (files created by
+    the dreamer), we scan language-guidelines/ then general-guidelines/
+    for an existing file whose stem matches the domain key. If nothing
+    exists yet, we default to language-guidelines/<domain>.md.
+    """
+    if domain in DOMAIN_MAP:
+        return root / DOMAIN_MAP[domain]
+
+    for subdir in ("language-guidelines", "general-guidelines"):
+        candidate = root / subdir / f"{domain}.md"
+        if candidate.exists():
+            return candidate
+
+    return root / "language-guidelines" / f"{domain}.md"
 
 
 def incorporate(
@@ -27,8 +48,7 @@ def incorporate(
     Returns the path that was written to.
     """
     root = Path(knowledge_root).expanduser().resolve()
-    relative = DOMAIN_MAP.get(domain, DOMAIN_MAP["general"])
-    target = root / relative
+    target = _resolve_domain_path(root, domain)
 
     target.parent.mkdir(parents=True, exist_ok=True)
 
@@ -59,8 +79,7 @@ def remove(
     import re
 
     root = Path(knowledge_root).expanduser().resolve()
-    relative = DOMAIN_MAP.get(domain, DOMAIN_MAP["general"])
-    target = root / relative
+    target = _resolve_domain_path(root, domain)
 
     if not target.exists():
         return None

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -104,3 +104,64 @@ def test_confidence_threshold_is_reasonable():
     # Sanity check: the threshold is a small positive number. If this
     # ever changes dramatically it's worth re-tuning against real data.
     assert 0.0 < CONFIDENCE_THRESHOLD < 0.2
+
+
+def test_classify_routes_nodejs_to_nodejs(tmp_path):
+    corpus = load_corpus(tmp_path)
+    body = "Register Express middleware with app.use(); prefer named functions over anonymous callbacks."
+    assert classify(body, corpus) == "nodejs"
+
+
+def test_classify_nodejs_async_does_not_bleed_into_python(tmp_path):
+    """async/await/callback tokens should not pull nodejs packets into python."""
+    corpus = load_corpus(tmp_path)
+    body = "Prefer async/await over raw Promise chains in Node.js; wrap callbacks with util.promisify."
+    assert classify(body, corpus) == "nodejs"
+
+
+def test_load_corpus_discovers_extra_language_file(tmp_path):
+    """A file in language-guidelines/ not in DOMAIN_MAP is included as a domain."""
+    nodejs_path = tmp_path / "language-guidelines" / "nodejs.md"
+    nodejs_path.parent.mkdir(parents=True)
+    nodejs_path.write_text("Node.js Express npm async callbacks.")
+
+    corpus = load_corpus(tmp_path)
+    assert "nodejs" in corpus
+    assert "Express" in corpus["nodejs"]
+
+
+def test_load_corpus_discovers_extra_general_file(tmp_path):
+    """A file in general-guidelines/ not in DOMAIN_MAP is included as a domain."""
+    ops_path = tmp_path / "general-guidelines" / "ops.md"
+    ops_path.parent.mkdir(parents=True)
+    ops_path.write_text("Docker Kubernetes Helm deployment manifests.")
+
+    corpus = load_corpus(tmp_path)
+    assert "ops" in corpus
+    assert "Docker" in corpus["ops"]
+
+
+def test_classify_routes_to_dynamically_discovered_domain(tmp_path):
+    """classify() routes to a domain discovered from the filesystem, not just DOMAIN_MAP."""
+    nodejs_path = tmp_path / "language-guidelines" / "nodejs.md"
+    nodejs_path.parent.mkdir(parents=True)
+    nodejs_path.write_text(
+        "Node.js Express npm async callbacks Promise middleware "
+        "require module exports webpack babel eslint "
+        "Node.js Node.js Node.js Express Express Express"
+    )
+
+    corpus = load_corpus(tmp_path)
+    body = "Use Express middleware for request validation in Node.js APIs."
+    assert classify(body, corpus) == "nodejs"
+
+
+def test_discovered_domains_do_not_displace_builtin_seeds(tmp_path):
+    """Built-in seeds still work when extra files are present."""
+    nodejs_path = tmp_path / "language-guidelines" / "nodejs.md"
+    nodejs_path.parent.mkdir(parents=True)
+    nodejs_path.write_text("Node.js Express npm.")
+
+    corpus = load_corpus(tmp_path)
+    body = "Use async def with await for I/O-bound handlers; pytest-asyncio for coroutines."
+    assert classify(body, corpus) == "python"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -73,3 +73,33 @@ def test_block_format(tmp_path):
     assert "<!-- feed:#41 · akim.k · 2026-04-03T08:14:00Z -->" in content
     assert "Prefer virtual threads." in content
     assert content.count("---") >= 2
+
+
+def test_incorporate_dynamic_domain_uses_existing_file(tmp_path):
+    """incorporate() writes to an existing file for a domain not in DOMAIN_MAP."""
+    target = tmp_path / "language-guidelines" / "nodejs.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Node.js\n")
+
+    path = incorporate(tmp_path, 50, "alice", "2026-04-04T10:00:00Z", "nodejs", "Use ESM imports.")
+    assert path == target
+    assert "Use ESM imports." in target.read_text()
+
+
+def test_incorporate_dynamic_domain_creates_in_language_guidelines(tmp_path):
+    """incorporate() falls back to language-guidelines/<domain>.md for unknown domains."""
+    path = incorporate(tmp_path, 51, "bob", "2026-04-04T11:00:00Z", "rust", "Prefer owned types.")
+    assert path == tmp_path / "language-guidelines" / "rust.md"
+    assert path.exists()
+    assert "Prefer owned types." in path.read_text()
+
+
+def test_incorporate_dynamic_domain_general_guidelines_takes_priority(tmp_path):
+    """If the domain file lives in general-guidelines/, use that over creating a new one."""
+    target = tmp_path / "general-guidelines" / "security.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("# Security\n")
+
+    path = incorporate(tmp_path, 52, "carol", "2026-04-04T12:00:00Z", "security", "Hash passwords.")
+    assert path == target
+    assert "Hash passwords." in target.read_text()


### PR DESCRIPTION
- Add .claude/commands/dreamer.md — a Claude Code slash command that deduplicates, re-routes, invents new categories, splits bloated files, rebuilds the knowledge index, and writes a run log each pass
- Make load_corpus() discover extra .md files in language-guidelines/ and general-guidelines/ beyond the built-in DOMAIN_MAP, so dreamer-created files are picked up by the ingest router automatically
- Make incorporate() resolve paths for dynamic domains by scanning the filesystem before defaulting to language-guidelines/<domain>.md
- Add nodejs seed vocabulary and DOMAIN_MAP entry to fix misrouting of Node.js packets to python
- Update README: expand dreamer section, trim overall length, add nodejs to routing table