### PR TITLE
Redesign governor ruleset display

### DIFF
--- a/src/feed/governor/__init__.py
+++ b/src/feed/governor/__init__.py
@@ -25,12 +25,30 @@ def classify(body: str, sender: str, is_org_member: bool) -> tuple[RiskLevel, li
 def get_ruleset() -> list[dict]:
     """Return the active governor ruleset for display in the UI."""
     return [
-        {"type": "block", "description": "non-org sender (weight 10)"},
-        {"type": "block", "description": "shell pipe to interpreter — regex + AST (weight 10)"},
-        {"type": "block", "description": "destructive rm -rf via shell AST (weight 10)"},
-        {"type": "block", "description": "script tag in body (weight 10)"},
-        {"type": "flag", "description": "external URL in body (weight 2)"},
-        {"type": "flag", "description": "imperative language + code block (weight 2)"},
-        {"type": "trust", "description": "threat ≥ 10 · review ≥ 4 · clear < 4"},
-        {"type": "trust", "description": "body is normalized (unicode, html, base64) before matching"},
+        {
+            "group": "blocked",
+            "label": "\u25a0 Blocked \u2014 cannot be incorporated (each match scores 10)",
+            "rules": [
+                "Non-org sender",
+                "Shell pipe to interpreter",
+                "Destructive rm command",
+                "Script tag in body",
+            ],
+        },
+        {
+            "group": "flagged",
+            "label": "\u25b2 Flagged \u2014 requires your decision (each match scores 2)",
+            "rules": [
+                "External URL in body",
+                "Imperative language + code block",
+            ],
+        },
+        {
+            "group": "scoring",
+            "label": "\u25cf Scoring",
+            "rules": [
+                "Score \u2265 10 blocks the memory from being incorporated",
+                "Score \u2265 4 flags the memory for review",
+            ],
+        },
     ]

--- a/src/feed/static/index.html
+++ b/src/feed/static/index.html
@@ -619,20 +619,26 @@
 
     .rule-list { list-style: none; margin-bottom: 14px; }
 
+    .rule-group-header {
+      font-size: 9px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-top: 12px;
+      margin-bottom: 6px;
+      padding-bottom: 4px;
+      border-bottom: 1px solid var(--border);
+    }
+    .rule-group-header:first-child { margin-top: 0; }
+    .rule-group-header.blocked { color: var(--red-bright); }
+    .rule-group-header.flagged { color: var(--amber-bright); }
+    .rule-group-header.scoring { color: var(--green-bright); }
+
     .rule-list li {
-      display: flex;
-      align-items: flex-start;
-      gap: 8px;
       font-size: 11px;
-      padding: 4px 0;
+      padding: 3px 0 3px 22px;
       color: var(--text);
       line-height: 1.5;
     }
-
-    .rule-icon            { flex-shrink: 0; width: 14px; text-align: center; font-size: 12px; }
-    .rule-icon.trust      { color: var(--green-bright); text-shadow: 0 0 6px var(--green-glow); }
-    .rule-icon.block      { color: var(--red-bright);   text-shadow: 0 0 6px var(--red-glow);   }
-    .rule-icon.flag       { color: var(--amber-bright); text-shadow: 0 0 6px var(--amber-glow); }
 
     #governor-footer {
       font-size: 9px;
@@ -1057,12 +1063,12 @@
     try {
       const resp = await fetch('/api/governor');
       const data = await resp.json();
-      const rules = data.rules || [];
-      const iconMap = { trust: '✓', block: '✗', flag: '!' };
+      const groups = data.rules || [];
       const ul = document.getElementById('rule-list');
-      ul.innerHTML = rules.map(r => {
-        const icon = iconMap[r.type] || '·';
-        return `<li><span class="rule-icon ${r.type}">${icon}</span> ${escHtml(r.description)}</li>`;
+      ul.innerHTML = groups.map(g => {
+        const header = `<div class="rule-group-header ${escHtml(g.group)}">${escHtml(g.label)}</div>`;
+        const items = g.rules.map(r => `<li>${escHtml(r)}</li>`).join('');
+        return header + items;
       }).join('');
     } catch (e) { console.error('fetchGovernor failed', e); }
   }

--- a/static/index.html
+++ b/static/index.html
@@ -619,20 +619,26 @@
 
     .rule-list { list-style: none; margin-bottom: 14px; }
 
+    .rule-group-header {
+      font-size: 9px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-top: 12px;
+      margin-bottom: 6px;
+      padding-bottom: 4px;
+      border-bottom: 1px solid var(--border);
+    }
+    .rule-group-header:first-child { margin-top: 0; }
+    .rule-group-header.blocked { color: var(--red-bright); }
+    .rule-group-header.flagged { color: var(--amber-bright); }
+    .rule-group-header.scoring { color: var(--green-bright); }
+
     .rule-list li {
-      display: flex;
-      align-items: flex-start;
-      gap: 8px;
       font-size: 11px;
-      padding: 4px 0;
+      padding: 3px 0 3px 22px;
       color: var(--text);
       line-height: 1.5;
     }
-
-    .rule-icon            { flex-shrink: 0; width: 14px; text-align: center; font-size: 12px; }
-    .rule-icon.trust      { color: var(--green-bright); text-shadow: 0 0 6px var(--green-glow); }
-    .rule-icon.block      { color: var(--red-bright);   text-shadow: 0 0 6px var(--red-glow);   }
-    .rule-icon.flag       { color: var(--amber-bright); text-shadow: 0 0 6px var(--amber-glow); }
 
     #governor-footer {
       font-size: 9px;
@@ -1057,12 +1063,12 @@
     try {
       const resp = await fetch('/api/governor');
       const data = await resp.json();
-      const rules = data.rules || [];
-      const iconMap = { trust: '✓', block: '✗', flag: '!' };
+      const groups = data.rules || [];
       const ul = document.getElementById('rule-list');
-      ul.innerHTML = rules.map(r => {
-        const icon = iconMap[r.type] || '·';
-        return `<li><span class="rule-icon ${r.type}">${icon}</span> ${escHtml(r.description)}</li>`;
+      ul.innerHTML = groups.map(g => {
+        const header = `<div class="rule-group-header ${escHtml(g.group)}">${escHtml(g.label)}</div>`;
+        const items = g.rules.map(r => `<li>${escHtml(r)}</li>`).join('');
+        return header + items;
       }).join('');
     } catch (e) { console.error('fetchGovernor failed', e); }
   }


### PR DESCRIPTION
## Summary
- Replace flat icon-per-rule list with grouped severity sections (Blocked, Flagged, Scoring)
- Each group header explains what the severity level means in plain language (e.g. "cannot be incorporated", "requires your decision")
- Scoring section now describes thresholds in terms of user-visible behavior

## Test plan
- [ ] Verify `make test` passes (129 tests)
- [ ] Load the UI and confirm the governor section renders three grouped sections
- [ ] Check dark and light mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)